### PR TITLE
Tokenize away `\[` and `\]`

### DIFF
--- a/examples/tarski.ftl.tex
+++ b/examples/tarski.ftl.tex
@@ -166,12 +166,18 @@
     \begin{proof}
       Let $T$ be a subset of $S$.
       Let us show that $T$ has a supremum in $S$. \\
-        Define $P = \{x "in" U | f(x) \leq x "and" x "is an upper bound of" T "in" U\}$.
+        Define 
+        \[
+          P = \{x \in U \mid f(x) \leq x "and" x "is an upper bound of" T "in" U\} .
+        \]
         Take an infimum $p$ of $P$ in $U$. $f(p)$ is a lower bound of $P$ in $U$ and an upper bound of $T$ in $U$.
         Hence $p$ is a fixed point of $f$ and a supremum of $T$ in $S$.
       end. \\
       Let us show that $T$ has an infimum in $S$. \\
-        Define $Q = \{x "in" U | x \leq f(x) "and" x "is a lower bound of" T "in" U\}$.
+        Define 
+        \[
+          Q = \{x \in U \mid x \leq f(x) "and" x "is a lower bound of" T "in" U\} .
+        \]
         Take a supremum $q$ of $Q$ in $U$. $f(q)$ is an upper bound of $Q$ in $U$ and a lower bound of $T$ in $U$.
         Hence $q$ is a fixed point of $f$ and an infimum of $T$ in $S$.
       end.

--- a/src/SAD/Parser/Token.hs
+++ b/src/SAD/Parser/Token.hs
@@ -118,6 +118,13 @@ tokenize texState start = posToken texState start NoWhiteSpaceBefore
         (hd, rest) = Text.splitAt 2 s
         toks = posToken texState (advancePos pos "\\\\") WhiteSpaceBefore rest
 
+    -- We reuse the pattern parsing for sentences in order to parse LaTeX. Thus we simply tokenize
+    -- away math-mode markers like '\[' and '\]'
+    posToken texState pos _ s | useTex && hd `elem` ["\\[","\\]"] = toks
+      where 
+        (hd, rest) = Text.splitAt 2 s
+        toks = posToken texState (advancePos pos hd) WhiteSpaceBefore rest
+
     -- Process non-alphanumeric symbol or EOF.
     posToken texState pos whitespaceBefore s = case Text.uncons s of
       Nothing -> [EOF pos]
@@ -134,6 +141,8 @@ tokenize texState start = posToken texState start NoWhiteSpaceBefore
           newToks = expandTexCmd name (SourceRange pos pos') whitespaceBefore
           toks = posToken texState pos' WhiteSpaceBefore rest'
 
+      -- We reuse the pattern parsing for sentences in order to parse LaTeX. Thus we simply tokenize
+      -- away math-mode markers like '$'
       Just ('$', rest) | useTex -> posToken texState (advancePos pos "$") WhiteSpaceBefore rest
 
       -- We also tokenize away quotation marks, because they are intended to be used by the user


### PR DESCRIPTION
Now naproche ignores`\[` and `\]`, just as it currently does with `$`.