### PR TITLE
Make project compatible with GHC 9.6.X

### DIFF
--- a/src/SAD/Core/Base.hs
+++ b/src/SAD/Core/Base.hs
@@ -38,6 +38,7 @@ module SAD.Core.Base (
 ) where
 
 import Control.Applicative (Alternative(..))
+import Control.Monad (MonadPlus(..), liftM, ap, guard, when, unless)
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.IORef

--- a/src/SAD/Core/Check.hs
+++ b/src/SAD/Core/Check.hs
@@ -12,6 +12,7 @@ module SAD.Core.Check (fillDef) where
 
 import Data.Maybe (fromMaybe)
 import Data.Either (lefts,rights, isRight)
+import Control.Monad (MonadPlus(..), guard)
 import Control.Monad.Reader
 import Data.Text.Lazy qualified as Text
 

--- a/src/SAD/Core/Extract.hs
+++ b/src/SAD/Core/Extract.hs
@@ -19,6 +19,7 @@ module SAD.Core.Extract (
 import Data.Map qualified as Map
 import Data.List
 import Data.Maybe
+import Control.Monad (MonadPlus(..), guard)
 import Control.Monad.State
 import Control.Monad.Reader
 import Data.Text.Lazy qualified as Text

--- a/src/SAD/Core/Reason.hs
+++ b/src/SAD/Core/Reason.hs
@@ -27,6 +27,7 @@ import Data.Maybe (fromJust, fromMaybe, maybeToList)
 import Data.Monoid (Sum, getSum)
 import Data.Functor ((<&>))
 import System.Timeout (timeout)
+import Control.Monad (MonadPlus(..), guard, when, unless, msum, liftM2, liftM3)
 import Control.Monad.Writer qualified as W
 import Data.Map qualified as Map
 import Data.Set qualified as Set

--- a/src/SAD/Core/Rewrite.hs
+++ b/src/SAD/Core/Rewrite.hs
@@ -14,6 +14,7 @@ module SAD.Core.Rewrite (
 
 import Data.List
 import Data.Set qualified as Set
+import Control.Monad (MonadPlus(..), guard, when, unless)
 import Control.Monad.State
 import Data.Either
 import Control.Monad.Reader

--- a/src/SAD/Core/Verify.hs
+++ b/src/SAD/Core/Verify.hs
@@ -10,6 +10,7 @@ module SAD.Core.Verify (verifyRoot) where
 
 import Data.IORef (readIORef)
 import Data.Maybe (isJust)
+import Control.Monad (when, unless)
 import Control.Monad.Reader
 import Data.Text.Lazy qualified as Text
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-21.15
+resolver: lts-22.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The new version of the base library does no longer export a bunch of definitions from Control.Monad by default