### PR TITLE
Make notions hoverable/searchable in FLAMS

### DIFF
--- a/math/archive/articles/source/curry-paradox.ftl.en.tex
+++ b/math/archive/articles/source/curry-paradox.ftl.en.tex
@@ -3,10 +3,7 @@
 \libusepackage{copyright}
 \libinput{preamble}
 
-\newcommand{\varzero}{x_0}
-\newcommand{\abs}[2]{\lambda#1.\ #2}
-\newcommand{\app}[2]{(#1)(#2)}
-\newcommand{\fix}{\texttt{fix}}
+
 
 \title{Curry's Paradox in \Naproche}
 \author{Marcel Schütz}
@@ -17,11 +14,19 @@
 
 \importmodule[libraries/meta]{preliminaries.ftl}
 
+\symdef{varzero}{x_0}
+\symdef{abs}[args=2]{\comp\lambda#1\comp.\,#2}
+\symdef{app}[args=2]{\comp(#1\comp)\comp(#2\comp)}
+\symdef{fix}{\texttt{fix}}
+\symdef{impl}{\mathbin{\comp\rightarrow}}
 \symdecl*{beta reduction}
 \symdecl*{reflexivity}
 \symdecl*{modus ponens}
 \symdecl*{strengthening}
 \symdecl*{Curry Paradox}
+\symdecl*{expression}
+\symdecl*{variable}
+\symdecl*{true}
 
 \maketitle
 
@@ -36,30 +41,30 @@ expression that presupposes its own validity.
 untyped $\lambda$-calculus:
 
 \begin{forthel}
-  \begin{signature*}
-    An expression is a notion.
+  \begin{signature*}[for=expression]
+    An \emph{expression} is a notion.
   \end{signature*}
 
   Let $E, E'$ denote expressions.
 
-  \begin{signature*}
-    A variable is an expression.
+  \begin{signature*}[for=variable]
+    A \emph{variable} is an expression.
   \end{signature*}
 
-  \begin{signature*}
-    $\varzero$ is a variable.
+  \begin{signature*}[for=varzero]
+    $\emph{\varzero}$ is a variable.
   \end{signature*}
 
-  \begin{signature*}[title=Abstraction]
+  \begin{signature*}[title=Abstraction,for=abs]
     Let $x$ be a variable.
-    $\abs{x}{E}$ is an expression.
+    $\emph{\abs{x}{E}}$ is an expression.
   \end{signature*}
 
-  \begin{signature*}[title=Application]
-    $\app{E}{E'}$ is an expression.
+  \begin{signature*}[title=Application,for=app]
+    $\emph{\app{E}{E'}}$ is an expression.
   \end{signature*}
 
-  \begin{signature*}[title=Fixed-point combinator]
+  \begin{signature*}[title=Fixed-point combinator,for=fix]
     $\fix$ is an expression such that
     \[\app{\fix}{E} = \app{E}{\app{\fix}{E}}\]
     for every expression $E$.
@@ -76,28 +81,28 @@ logic:
   Let $E, E'$ denote expressions.
   Let $x$ denote a variable.
 
-  \begin{signature*}[title=Implication]
-    $E \rightarrow E'$ is an expression.
+  \begin{signature*}[title=Implication,for=impl]
+    $\emph{E \impl E'}$ is an expression.
   \end{signature*}
 
-  \begin{signature*}[title=Truth]
-    $E$ is true is a relation.
+  \begin{signature*}[title=Truth,for=true]
+    $E$ is \emph{true} is a relation.
   \end{signature*}
 
   \begin{axiom*}[title=$\beta$-reduction,name=beta reduction]
-    $\app{\abs{x}{x \rightarrow E'}}{E} = E \rightarrow E'$.
+    $\app{\abs{x}{x \impl E'}}{E} = E \impl E'$.
   \end{axiom*}
 
   \begin{axiom*}[title=Reflexivity,name=reflexivity]
-    $E \rightarrow E$ is true.
+    $E \impl E$ is true.
   \end{axiom*}
 
   \begin{axiom*}[title=Modus Ponens,name=modus ponens]
-    If $E$ is true and $E \rightarrow E'$ is true then $E'$ is true.
+    If $E$ is true and $E \impl E'$ is true then $E'$ is true.
   \end{axiom*}
 
   \begin{axiom*}[title=Strengthening,name=strengthening]
-    If $E \rightarrow (E \rightarrow E')$ is true then $E \rightarrow E'$ is true.
+    If $E \impl (E \impl E')$ is true then $E \impl E'$ is true.
   \end{axiom*}
 \end{forthel}
 
@@ -107,7 +112,7 @@ logic:
 \noindent Using the fixpoint combinator from above we can formulate a 
 self-referential expression $X$ of the form ``If $X$ is true then $E$ is
 true'' for any arbitrary expression $E$ by defining
-$X = \app{\fix}{\abs{\varzero}{\varzero \rightarrow E}}$.
+$X = \app{\fix}{\abs{\varzero}{\varzero \impl E}}$.
 From the existence of such an expression $X$ together with the above axioms 
 we can then derive that any expression $E$ is true.
 
@@ -117,13 +122,13 @@ we can then derive that any expression $E$ is true.
   \end{theorem*}
   \begin{proof}
     Let $E$ be an expression.
-    Take $N = \abs{\varzero}{\varzero \rightarrow E}$ and $X = \app{\fix}{N}.$
+    Take $N = \abs{\varzero}{\varzero \impl E}$ and $X = \app{\fix}{N}.$
 
-    (1) Then $X = \app{N}{X} = X \rightarrow E$ (by \sr{beta reduction}{$\beta$-reduction}).
+    (1) Then $X = \app{N}{X} = X \impl E$ (by \sr{beta reduction}{$\beta$-reduction}).
 
-    Hence $X \rightarrow (X \rightarrow E)$ is true (by 1, \sn{reflexivity}).
+    Hence $X \impl (X \impl E)$ is true (by 1, \sn{reflexivity}).
 
-    (2) Thus $X \rightarrow E$ is true (by \sn{strengthening}).
+    (2) Thus $X \impl E$ is true (by \sn{strengthening}).
 
     (3) Therefore $X$ is true (by 1, 2).
 

--- a/math/archive/articles/source/furstenberg.ftl.en.tex
+++ b/math/archive/articles/source/furstenberg.ftl.en.tex
@@ -3,10 +3,6 @@
 \libusepackage{copyright}
 \libinput{preamble}
 
-\newcommand{\N}{\mathrm{N}}
-\newcommand{\Int}{\mathbb{Z}}
-\newcommand{\Ps}{\mathrm{P}}
-
 \title{Furstenberg's Proof of the Infinitude of Primes in \Naproche}
 \author{Andrei Paskevich, Marcel Schütz}
 \date{2025}
@@ -20,6 +16,14 @@
 \importmodule[libraries/set-theory]{zfc.ftl}
 \importmodule[libraries/foundations]{closure-under-finite-unions.ftl}
 
+\symdef{compl}[args=1]{#1^{\comp\complement}}
+\symdef{ArithSeq}[args=2]{\comp{\mathrm{N}}_{#1\comp,#2}}
+\symdef{Int}{\mathbb{Z}}
+\symdef{PrimeSeq}{\mathrm{P}}
+\symdecl*{open}
+\symdecl*{system of open sets}
+\symdecl*{closed}
+\symdecl*{system of closed sets}
 \symdecl*{Furstenberg}
 
 \noindent This is a formalization of Furstenberg's topological proof of the
@@ -35,12 +39,12 @@ $\Nat$ without substantially changing the proof.}
   Let $n, m, k$ denote natural numbers.
   Let $p, q$ denote nonzero natural numbers.
 
-  \begin{definition}
+  \begin{definition}[for=compl]
     Let $A$ be a subset of $\Nat$.
-    $A^\complement = \Nat \SETdiff A$.
+    $\compl{A} = \Nat \SETdiff A$.
   \end{definition}
 
-  Let the complement of $A$ stand for $A^\complement$.
+  Let the complement of $A$ stand for $\compl{A}$.
 
   \begin{lemma}
     The complement of any subset of $\Nat$ is a subset of $\Nat$.
@@ -48,11 +52,11 @@ $\Nat$ without substantially changing the proof.}
 \end{forthel}
 
 Towards a suitable topology on $\Nat$ let us define \textit{arithmetic
-sequences} $\N_{n, q}$ on $\Nat$.
+sequences} $\ArithSeq{n}{q}$ on $\Nat$.
 
 \begin{forthel}
-  \begin{definition}
-    $\N_{n, q} = \SClass{m}{\Nat}{\NATcong{m}{n}{q}}$.
+  \begin{definition}[for=ArithSeq]
+    $\ArithSeq{n}{q} = \SClass{m}{\Nat}{\NATcong{m}{n}{q}}$.
   \end{definition}
 \end{forthel}
 
@@ -60,13 +64,13 @@ This allows us to define the \textit{evenly spaced natural number
 topology} on $\Nat$, whose open sets are defined as follows.
 
 \begin{forthel}
-  \begin{definition}
+  \begin{definition}[for=open]
     Let $U$ be a subset of $\Nat$.
-    $U$ is open iff for any $n \in U$ there exists a $q$ such that
-    $\N_{n, q} \SETinclude U$.
+    $U$ is open iff for any $n \Elem U$ there exists a $q$ such that
+    $\ArithSeq{n}{q} \SETinclude U$.
   \end{definition}
 
-  \begin{definition}
+  \begin{definition}[for=system of open sets]
     A system of open sets is a system of sets $S$ such that every element of
     $S$ is an open subset of $\Nat$.
   \end{definition}
@@ -93,18 +97,18 @@ We can show that the open sets indeed form a topology on $\Nat$.
     Then $U \SETintersect V$ is open.
   \end{lemma}
   \begin{proof}
-    Let $n \in U \SETintersect V$.
-    Take a $q$ such that $\N_{n, q} \SETinclude U$.
-    Take a $p$ such that $\N_{n, p} \SETinclude V$.
+    Let $n \Elem U \SETintersect V$.
+    Take a $q$ such that $\ArithSeq{n}{q} \SETinclude U$.
+    Take a $p$ such that $\ArithSeq{n}{p} \SETinclude V$.
     Then $p \NATmul q \NotEq \NATzero$.
 
-    Let us show that $\N_{n, p \NATmul q} \SETinclude U \SETintersect V$.
-      Let $m \in \N_{n, p \NATmul q}$.
+    Let us show that $\ArithSeq{n}{p \NATmul q} \SETinclude U \SETintersect V$.
+      Let $m \Elem \ArithSeq{n}{p \NATmul q}$.
       We have $\NATcong{m}{n}{p \NATmul q}$.
       Hence $\NATcong{m}{n}{p}$ and $\NATcong{m}{n}{q}$.
-      Thus $m \in \N_{n, p}$ and $m \in \N_{n, q}$.
-      Therefore $m \in U$ and $m \in V$.
-      Consequently $m \in U \SETintersect V$.
+      Thus $m \Elem \ArithSeq{n}{p}$ and $m \Elem \ArithSeq{n}{q}$.
+      Therefore $m \Elem U$ and $m \Elem V$.
+      Consequently $m \Elem U \SETintersect V$.
     End.
   \end{proof}
 
@@ -113,10 +117,10 @@ We can show that the open sets indeed form a topology on $\Nat$.
     Then $\SETunionover S$ is open.
   \end{lemma}
   \begin{proof}
-    Let $n \in \SETunionover S$.
-    Take a set $M$ such that $n \in M \in S$.
-    Consider a $q$ such that $\N_{n, q} \SETinclude M$.
-    Then $\N_{n, q} \SETinclude \SETunionover S$.
+    Let $n \Elem \SETunionover S$.
+    Take a set $M$ such that $n \Elem M \Elem S$.
+    Consider a $q$ such that $\ArithSeq{n}{q} \SETinclude M$.
+    Then $\ArithSeq{n}{q} \SETinclude \SETunionover S$.
   \end{proof}
 \end{forthel}
 
@@ -125,12 +129,12 @@ with a characterization of closed sets whose key property is that they are
 closed under finite unions.
 
 \begin{forthel}
-  \begin{definition}
+  \begin{definition}[for=closed]
     Let $A$ be a subset of $\Nat$.
-    $A$ is closed iff $A^\complement$ is open.
+    $A$ is closed iff $\compl{A}$ is open.
   \end{definition}
 
-  \begin{definition}
+  \begin{definition}[for=system of closed sets]
     A system of closed sets is a system of sets $S$ such that every element of
     $S$ is a closed subset of $\Nat$.
   \end{definition}
@@ -152,17 +156,17 @@ closed under finite unions.
   \begin{proof}
     Define $C = \CClass{X}{X \text{ is a closed subset of } \Nat}$.
 
-    Let us show that $A \SETunion B \in C$ for any $A, B \in C$.
-      Let $A, B \in C$.
+    Let us show that $A \SETunion B \Elem C$ for any $A, B \Elem C$.
+      Let $A, B \Elem C$.
       Then $A, B$ are closed subsets of $\Nat$.
-      We have $((A \SETunion B)^\complement) = A^\complement \SETintersect B^\complement$. %!
-      $A^\complement$ and $B^\complement$ are open.
-      Hence $A^\complement \SETintersect B^\complement$ is open.
+      We have $(\compl{A \SETunion B}) \Eq \compl{A} \SETintersect \compl{B}$. %!
+      $\compl{A}$ and $\compl{B}$ are open.
+      Hence $\compl{A} \SETintersect \compl{B}$ is open.
       Thus $A \SETunion B$ is a closed subset of $\Nat$.
     End.
 
     Therefore $C$ is closed under finite unions.
-    Consequently $\SETunionover S \in C$.
+    Consequently $\SETunionover S \Elem C$.
     Indeed $S$ is a subset of $C$.
   \end{proof}
 \end{forthel}
@@ -172,72 +176,72 @@ sequences are closed.
 
 \begin{forthel}
   \begin{lemma}
-    $\N_{n, q}$ is closed.
+    $\ArithSeq{n}{q}$ is closed.
   \end{lemma}
   \begin{proof}
-    Let $m \in (\N_{n, q})^\complement$.
+    Let $m \Elem \compl{\ArithSeq{n}{q}}$.
 
-    Let us show that $\N_{m, q} \SETinclude (\N_{n, q})^\complement$.
-      Let $k \in \N_{m, q}$.
-      Assume $k \notin (\N_{n, q})^\complement$.
+    Let us show that $\ArithSeq{m}{q} \SETinclude \compl{\ArithSeq{n}{q}}$.
+      Let $k \Elem \ArithSeq{m}{q}$.
+      Assume $k \NotElem \compl{\ArithSeq{n}{q}}$.
       Then $\NATcong{k}{m}{q}$ and $\NATcong{n}{k}{q}$.
       Hence $\NATcong{m}{n}{q}$.
-      Therefore $m \in \N_{n, q}$.
+      Therefore $m \Elem \ArithSeq{n}{q}$.
       Contradiction.
     End.
   \end{proof}
 \end{forthel}
 
-Identifying each prime number $p$ with the arithmetic sequence $\N_{0, p}$
+Identifying each prime number $p$ with the arithmetic sequence $\ArithSeq{0}{p}$
 yields a bijection between the set $\Prime$ of all prime numbers and the set
-$\Ps$ of all such sequences $\N_{0, p}$.
+$\PrimeSeq$ of all such sequences $\ArithSeq{0}{p}$.
 Thus to show that there are infinitely many primes it suffices to show that
-$\Ps$ is infinite.
+$\PrimeSeq$ is infinite.
 
 \begin{forthel}
-  \begin{definition}
-    $\Ps = \CClass{\N_{\NATzero, p}}{p \in \Prime}$.
+  \begin{definition}[for=PrimeSeq]
+    $\PrimeSeq = \CClass{\ArithSeq{\NATzero}{p}}{p \Elem \Prime}$.
   \end{definition}
 
   \begin{lemma}
-    $\Ps$ is a system of closed sets.
+    $\PrimeSeq$ is a system of closed sets.
   \end{lemma}
   \begin{proof}
-    $\N_{\NATzero, p}$ is a closed subset of $\Nat$ for every $p \in \Prime$.
+    $\ArithSeq{\NATzero}{p}$ is a closed subset of $\Nat$ for every $p \Elem \Prime$.
   \end{proof}
 
   \begin{lemma}
-    $\Ps$ is a set that is equinumerous to $\Prime$.
+    $\PrimeSeq$ is a set that is equinumerous to $\Prime$.
   \end{lemma}
   \begin{proof}
-    (1) $\Ps$ is a set.
-    Indeed $\Ps \SETinclude \SETpow(\Nat)$.
+    (1) $\PrimeSeq$ is a set.
+    Indeed $\PrimeSeq \SETinclude \SETpow(\Nat)$.
 
-    (2) $\Ps$ is equinumerous to $\Prime$.
+    (2) $\PrimeSeq$ is equinumerous to $\Prime$.
     \begin{proof}
-      Define $f(p) = \N_{\NATzero,p}$ for $p \in \Prime$.
+      Define $f(p) = \ArithSeq{\NATzero}{p}$ for $p \Elem \Prime$.
 
       Let us show that $f$ is injective.
-        Let $p, q \in \Prime$.
-        Assume $f(p) = f(q)$.
-        Then $\N_{\NATzero, p} = \N_{\NATzero, q}$.
-        We have $\N_{\NATzero, p} = \SClass{m}{\Nat}{\NATcong{m}{\NATzero}{p}}$ and
-        $\N_{\NATzero, q} = \SClass{m}{\Nat}{\NATcong{m}{\NATzero}{q}}$.
+        Let $p, q \Elem \Prime$.
+        Assume $f(p) \Eq f(q)$.
+        Then $\ArithSeq{\NATzero}{p} \Eq \ArithSeq{\NATzero}{q}$.
+        We have $\ArithSeq{\NATzero}{p} = \SClass{m}{\Nat}{\NATcong{m}{\NATzero}{p}}$ and
+        $\ArithSeq{\NATzero}{q} = \SClass{m}{\Nat}{\NATcong{m}{\NATzero}{q}}$.
 
-        We can show that for all $m \in \Nat$ we have $p \NATmid m$ iff $q \NATmid m$.
-          Let $m \in \Nat$.
+        We can show that for all $m \Elem \Nat$ we have $p \NATmid m$ iff $q \NATmid m$.
+          Let $m \Elem \Nat$.
           Then $\NATcong{m}{\NATzero}{p}$ iff $\NATcong{m}{\NATzero}{q}$.
-          Thus $m \NATmod p = \NATzero \NATmod p$ iff $m \NATmod q = \NATzero \NATmod q$.
-          We have $\NATzero \NATmod p = \NATzero = \NATzero \NATmod q$.
-          Hence $m \NATmod p = \NATzero$ iff $m \NATmod q = \NATzero$.
+          Thus $m \NATmod p \Eq \NATzero \NATmod p$ iff $m \NATmod q \Eq \NATzero \NATmod q$.
+          We have $\NATzero \NATmod p \Eq \NATzero \Eq \NATzero \NATmod q$.
+          Hence $m \NATmod p \Eq \NATzero$ iff $m \NATmod q \Eq \NATzero$.
           Therefore $p \NATmid m$ iff $q \NATmid m$.
         End.
 
-        Consequently $p = q$.
+        Consequently $p \Eq q$.
       End.
 
-      $f$ is surjective onto $\Ps$.
-      Thus $f$ is a bijection between $\Prime$ and $\Ps$.
+      $f$ is surjective onto $\PrimeSeq$.
+      Thus $f$ is a bijection between $\Prime$ and $\PrimeSeq$.
     \end{proof}
   \end{proof}
 
@@ -245,48 +249,48 @@ $\Ps$ is infinite.
     $\Prime$ is infinite.
   \end{theorem}
   \begin{proof}
-    $\SETunionover \Ps$ is a subset of $\Nat$.
+    $\SETunionover \PrimeSeq$ is a subset of $\Nat$.
 
-    Let us show that for any $n \in \Nat$ we have $n \in \SETunionover \Ps$ iff $n$
+    Let us show that for any $n \Elem \Nat$ we have $n \Elem \SETunionover \PrimeSeq$ iff $n$
     has a prime divisor.
-      Let $n \in \Nat$.
+      Let $n \Elem \Nat$.
 
-      If $n$ has a prime divisor then $n$ belongs to $\SETunionover \Ps$.
+      If $n$ has a prime divisor then $n$ belongs to $\SETunionover \PrimeSeq$.
       \begin{proof}
         Assume $n$ has a prime divisor.
         Take a prime divisor $p$ of $n$.
-        We have $\N_{\NATzero, p} \in \Ps$.
-        Hence $n \in \N_{\NATzero, p}$.
+        We have $\ArithSeq{\NATzero}{p} \Elem \PrimeSeq$.
+        Hence $n \Elem \ArithSeq{\NATzero}{p}$.
       \end{proof}
 
-      If $n$ belongs to $\SETunionover \Ps$ then $n$ has a prime divisor.
+      If $n$ belongs to $\SETunionover \PrimeSeq$ then $n$ has a prime divisor.
       \begin{proof}
-        Assume that $n$ belongs to $\SETunionover \Ps$.
-        Take a prime number $r$ such that $n \in \N_{\NATzero, r}$.
+        Assume that $n$ belongs to $\SETunionover \PrimeSeq$.
+        Take a prime number $r$ such that $n \Elem \ArithSeq{\NATzero}{r}$.
         Hence $\NATcong{n}{\NATzero}{r}$.
-        Thus $n \NATmod r = \NATzero \NATmod r = \NATzero$.
+        Thus $n \NATmod r \Eq \NATzero \NATmod r \Eq \NATzero$.
         Therefore $r$ is a prime divisor of $n$.
       \end{proof}
     End.
 
-    Hence For all $n \in \Nat$ we have $n \in (\SETunionover \Ps)^\complement$ iff
+    Hence For all $n \Elem \Nat$ we have $n \Elem \compl{\SETunionover \PrimeSeq}$ iff
     $n$ has no prime divisor.
     $\NATone$ has no prime divisor and any natural number having no prime
     divisor is equal to $\NATone$.
-    Therefore $(\SETunionover \Ps)^\complement = \SETsingleton{\NATone}$.
-    Indeed $((\SETunionover \Ps)^\complement) \SETinclude \SETsingleton{\NATone}$ and $\SETsingleton{\NATone}
-    \SETinclude (\SETunionover \Ps)^\complement$. %!
+    Therefore $\compl{\SETunionover \PrimeSeq} \Eq \SETsingleton{\NATone}$.
+    Indeed $\compl{\SETunionover \PrimeSeq} \SETinclude \SETsingleton{\NATone}$ and $\SETsingleton{\NATone}
+    \SETinclude \compl{\SETunionover \PrimeSeq}$.
 
-    $\Ps$ is infinite.
+    $\PrimeSeq$ is infinite.
     \begin{proof}[method=contradiction]
-      Assume that $\Ps$ is finite.
-      Then $\SETunionover \Ps$ is closed and $(\SETunionover \Ps)^\complement$ is open.
-      Take a $p$ such that $\N_{\NATone, p} \SETinclude (\SETunionover \Ps)^\complement$.
-      $\NATone \NATplus p$ is an element of $\N_{\NATone, p}$.
+      Assume that $\PrimeSeq$ is finite.
+      Then $\SETunionover \PrimeSeq$ is closed and $\compl{\SETunionover \PrimeSeq}$ is open.
+      Take a $p$ such that $\ArithSeq{\NATone}{p} \SETinclude \compl{\SETunionover \PrimeSeq}$.
+      $\NATone \NATplus p$ is an element of $\ArithSeq{\NATone}{p}$.
       Indeed $\NATcong{\NATone \NATplus p}{\NATone}{p}$
       (by \sn{congruency of sum}).
       $\NATone \NATplus p$ is not equal to $\NATone$.
-      Hence $\NATone \NATplus p \notin (\SETunionover \Ps)^\complement$.
+      Hence $\NATone \NATplus p \NotElem \compl{\SETunionover \PrimeSeq}$.
       Contradiction.
     \end{proof}
   \end{proof}

--- a/math/archive/articles/source/koenig.ftl.en.tex
+++ b/math/archive/articles/source/koenig.ftl.en.tex
@@ -8,11 +8,6 @@
 \author{Steffen Frerix, Peter Koepke, Marcel Schütz}
 \date{2025}
 
-\newcommand{\SumSet}[2]{\bigsqcup_{i \Elem #2} #1_{i}}
-\newcommand{\Sum}[2]{\sum_{i \Elem #2} #1_{i}}
-\newcommand{\ProdSet}[2]{\bigtimes_{i \Elem #2} #1_{i}}
-\newcommand{\Prod}[2]{\prod_{i \Elem #2} #1_{i}}
-
 
 \begin{document}
 \begin{smodule}{koenig.ftl}
@@ -22,6 +17,11 @@
 \importmodule[libraries/set-theory]{cardinals-and-maps.ftl}
 \importmodule[libraries/set-theory]{two.ftl}
 
+\symdef{SumSet}[args=2]{\comp\bigsqcup_{\comp i\mathrel{\comp\in}#2}#1_{\comp i}}
+\symdef{Sum}[args=2]{\comp\sum_{i\mathrel{\comp\in}#2}#1_{\comp i}}
+\symdef{ProdSet}[args=2]{\comp\bigtimes_{\comp i\mathrel{\comp\in}#2}#1_{\comp i}}
+\symdef{Prod}[args=2]{\comp\prod_{\comp i\mathrel{\comp\in}#2}#1_{\comp i}}
+\symdecl*{sequence of cardinals}
 \symdecl*{Koenig}
 
 \noindent Kőnig's Theorem is an important set-theoretical result about the
@@ -39,12 +39,12 @@ $\kappa \ORDless \ORDtwo^\kappa$.
 
   [synonym sequence/-s]
 
-  \begin{definition*}
+  \begin{definition*}[for=sequence of cardinals]
     A sequence of cardinals on $D$ is a function $\kappa$ such that
     $\Dom(\kappa) \Eq D$ and $\kappa_{i}$ is a cardinal for every element $i$ of $D$.
   \end{definition*}
 
-  \begin{definition*}
+  \begin{definition*}[for=SumSet]
     Let $\kappa$ be a sequence of cardinals on $D$.
     \[ \SumSet{\kappa}{D} = \CClass{(n,i)}{\text{$i$ is an element of $D$ and $n$ is an element of $\kappa_{i}$}}. \]
   \end{definition*}
@@ -54,12 +54,12 @@ $\kappa \ORDless \ORDtwo^\kappa$.
     Then $\SumSet{\kappa}{D}$ is a set.
   \end{axiom*}
 
-  \begin{definition*}
+  \begin{definition*}[for=Sum]
     Let $\kappa$ be a sequence of cardinals on $D$.
     \[ \Sum{\kappa}{D} = \SETcard{ \SumSet{\kappa}{D} }. \]
   \end{definition*}
 
-  \begin{definition*}
+  \begin{definition*}[for=ProdSet]
     Let $\kappa$ be a sequence of cardinals on $D$.
     \[ \ProdSet{\kappa}{D} = \CClass{f}{\classtext{$f$ is a function and $\Dom(f) \Eq D$ and $f(i)$ is an element of $\kappa_{i}$ for every element $i$ of $D$}}. \]
   \end{definition*}
@@ -69,7 +69,7 @@ $\kappa \ORDless \ORDtwo^\kappa$.
     Then $\ProdSet{\kappa}{D}$ is a set.
   \end{axiom*}
 
-  \begin{definition*}
+  \begin{definition*}[for=Prod]
     Let $\kappa$ be a sequence of cardinals on $D$.
     \[ \Prod{\kappa}{D} = \SETcard{ \ProdSet{\kappa}{D} }. \]
   \end{definition*}

--- a/math/archive/articles/source/little-gauss.ftl.en.tex
+++ b/math/archive/articles/source/little-gauss.ftl.en.tex
@@ -3,8 +3,6 @@
 \libusepackage{copyright}
 \libinput{preamble}
 
-\newcommand{\gauss}{\mathcal{G}}
-
 \title{``Little Gauß''' Theorem in \Naproche}
 \author{Christian Schöner, Marcel Schütz}
 \date{2025}
@@ -15,6 +13,7 @@
 
 \importmodule[libraries/arithmetics]{multiplication.ftl}
 
+\symdef{gauss}{\mathcal{G}}
 \symdecl*{Little Gauss}
 
 \noindent This is a formalization of ``Little Gauß''' Theorem, i.e. of
@@ -28,7 +27,7 @@ $\gauss(n \NATplus \NATone) = \gauss(n) \NATplus (n \NATplus \NATone)$:
 \begin{forthel}
   Let $n$ denote a natural number.
 
-  \begin{signature*}
+  \begin{signature*}[for=gauss]
     $\gauss(n)$ is a natural number.
   \end{signature*}
 

--- a/math/archive/articles/source/peano.ftl.en.tex
+++ b/math/archive/articles/source/peano.ftl.en.tex
@@ -26,6 +26,7 @@
 \symdef{succ}[args=1]{\comp{\textsf{succ}}\dobrackets{#1}}
 \symdef{plus}{\mathrel{\comp+}}
 \symdef{triplus}[args=3]{#1\mathrel{\comp+}#2\mathrel{\comp+}#3}
+\symdecl*{number}
 
 % (An approximation to) Peano's original notation:
 \notation*{True}[peano]{\mathrm V}
@@ -56,19 +57,19 @@ number of theorems about addition of natural numbers.
 \begin{forthel}
   Let $a,b,c,d$ denote mathematical objects.
 
-  \begin{signature*}
+  \begin{signature*}[for=number]
     A \emph{number} is a mathematical object.
   \end{signature*}
 
-  \begin{definition*}
+  \begin{definition*}[for=Nat]
     $\emph{\Nat}$ is the class of all numbers.
   \end{definition*}
 
-  \begin{signature*}
+  \begin{signature*}[for=one]
     $\emph{\one}$ is a mathematical object.
   \end{signature*}
 
-  \begin{signature*}
+  \begin{signature*}[for=succ]
     $\emph{\succ{a}}$ is a mathematical object.
   \end{signature*}
 \end{forthel}
@@ -201,7 +202,7 @@ number of theorems about addition of natural numbers.
 \symdecl*{P18}
 
 \begin{forthel}
-  \begin{signature*}
+  \begin{signature*}[for=plus]
     $\emph{a \plus b}$ is a mathematical object.
   \end{signature*}
 
@@ -259,7 +260,7 @@ number of theorems about addition of natural numbers.
     Thus $a \plus b \Elem \Nat$.
   \end{proof}
 
-  \begin{definition*}[title=20]
+  \begin{definition*}[title=20,for=triplus]
     $\emph{\triplus{a}{b}{c}} = (a \plus b) \plus c$.
   \end{definition*}
 

--- a/math/archive/articles/source/russell-myhill-paradox.ftl.en.tex
+++ b/math/archive/articles/source/russell-myhill-paradox.ftl.en.tex
@@ -12,6 +12,10 @@
 
 \usemodule[libraries/meta]{preliminaries.ftl}
 
+\symdef{LogProd}[name=logical product]{\mathop{\sqcap}}
+\symdecl*{proposition}
+\symdecl*{true}
+\symdecl*{system of propositions}
 \symdecl*{Russell-Myhill Paradox}
 
 \maketitle
@@ -24,39 +28,36 @@ It was discussed in Russell's 1903 \emph{Principles of Mathematics}
 \cite{Myhill1958}.
 
 \begin{forthel}
-  \begin{signature*}
-    A proposition is an object.
+  \begin{signature*}[for=proposition]
+    A \emph{proposition} is an object.
   \end{signature*}
 
-  \begin{signature*}
+  \begin{signature*}[for=true]
     Let $p$ be a proposition.
-    $p$ is true is an atom.
+    $p$ is \emph{true} is an atom.
   \end{signature*}
 
-  [synonym system/-s]
-
-  \begin{definition*}
-    A system of propositions is a class $P$ such that every element of $P$ is a proposition.
+  \begin{definition*}[for=system of propositions]
+    A \emph{system of propositions} is a class $P$ such that every element of $P$ is a proposition.
   \end{definition*}
 
-  \begin{signature*}
+  \begin{signature*}[for=logical product]
     Let $P$ be a system of propositions.
-    The logical product of $P$ is a proposition $p$ such that $p$ is true iff every element of $P$ is true.
+    The \emph{logical product of $P$} is a proposition $p$ such that $p$ is true iff every element of $P$ is true.
+    Let $\emph{\LogProd P}$ denote the logical product of $P$.
   \end{signature*}
-  
-  Let $\sqcap P$ denote the logical product of $P$.
   
   \begin{theorem*}[title=Russell-Myhill Paradox,name=Russell-Myhill Paradox]
     It is wrong that
-    \[ \sqcap P = \sqcap Q \Implies P = Q \]
+    \[ \LogProd P \Eq \LogProd Q \Implies P \Eq Q \]
     for all systems of propositions $P, Q$.
   \end{theorem*}
   \begin{proof}
     Assume the contrary.
-    Define $Q = \CClass{q}{\text{there exists a system of propositions } P \text{ such that } q = \sqcap P \text{ and } q \notin P}$.
-    Consider $q = \sqcap Q$.
-    Then for any system of propositions $P$ such that $\sqcap P = q$ we have $P = Q$.
-    Hence $q \in Q$ iff $q \notin Q$.
+    Define $Q = \CClass{q}{\text{there exists a system of propositions } P \text{ such that } q \Eq \LogProd P \text{ and } q \NotElem P}$.
+    Consider $q = \LogProd Q$.
+    Then for any system of propositions $P$ such that $\LogProd P \Eq q$ we have $P \Eq Q$.
+    Hence $q \Elem Q$ iff $q \NotElem Q$.
     Contradiction.
   \end{proof}
 \end{forthel}

--- a/math/archive/articles/source/russell-paradox.ftl.en.tex
+++ b/math/archive/articles/source/russell-paradox.ftl.en.tex
@@ -28,9 +28,9 @@ Not every class is a set.
   \end{theorem}
   \begin{proof}[forthel]
     Assume the contrary.
-    Define $R = \CClass{x}{x \text{ is a set such that } x \notin x}$.
+    Define $R = \CClass{x}{x \text{ is a set such that } x \NotElem x}$.
     Then $R$ is a set.
-    Hence $R \in R$ iff $R \notin R$.
+    Hence $R \Elem R$ iff $R \NotElem R$.
     Contradiction.
   \end{proof}
 \end{forthel}

--- a/math/archive/articles/source/socrates.ftl.en.tex
+++ b/math/archive/articles/source/socrates.ftl.en.tex
@@ -43,28 +43,28 @@ We can formalize this syllogism in \Naproche without changing its wording:
   \end{proof}
 \end{forthel}
 
-A similar syllogism was given by Sextus Empiricus in his \textit{Outlines of
-Pyrrhonism} \cite{SextusEmpiricus1933}:
-\begin{center}
-  \begin{tabular}{c}
-    Socrates is human. \\
-    Every human being is an animal. \\
-    \hline
-    Therefore Socrates is an animal.
-  \end{tabular}
-\end{center}
-Again, this syllogism can be adopted word-by-word to \Naproche:
-
-\begin{forthel}
-  \begin{theorem}[title=Sextus Empiricus' Syllogism,name=Sextus Empiricus Syllogism]
-    Socrates is an animal.
-  \end{theorem}
-  \begin{proof}
-    Socrates is human.
-    Every human being is an animal.
-    Therefore Socrates is an animal.
-  \end{proof}
-\end{forthel}
+%A similar syllogism was given by Sextus Empiricus in his \textit{Outlines of
+%Pyrrhonism} \cite{SextusEmpiricus1933}:
+%\begin{center}
+%  \begin{tabular}{c}
+%    Socrates is human. \\
+%    Every human being is an animal. \\
+%    \hline
+%    Therefore Socrates is an animal.
+%  \end{tabular}
+%\end{center}
+%Again, this syllogism can be adopted word-by-word to \Naproche:
+%
+%\begin{forthel}
+%  \begin{theorem}[title=Sextus Empiricus' Syllogism,name=Sextus Empiricus Syllogism]
+%    Socrates is an animal.
+%  \end{theorem}
+%  \begin{proof}
+%    Socrates is human. % AMBIGUITY ERROR!
+%    Every human being is an animal. % AMBIGUITY ERROR!
+%    Therefore Socrates is an animal.
+%  \end{proof}
+%\end{forthel}
 
 \printbibliography
 \printlicense[CcByNcSa]{Marcel Schütz (2025)}

--- a/math/archive/articles/source/transfinite-recursion.ftl.en.tex
+++ b/math/archive/articles/source/transfinite-recursion.ftl.en.tex
@@ -75,7 +75,7 @@ all ordinals $\alpha$.
       Let $\alpha$ be an ordinal.
       Assume that every ordinal less than $\alpha$ lies in $\Phi$.
       Then for all $y \Elem \alpha$ there exists a map $h$ to $A$ such that $h$ is recursive regarding $G$ and $y \Elem \Dom(h)$.
-      Define $H'(y) =$ ``choose a map $h$ to $A$ such that $h$ is recursive regarding $G$ and $y \Elem \Dom(h)$ in $h(y)$'' for $y \in \alpha$.
+      Define $H'(y) =$ ``choose a map $h$ to $A$ such that $h$ is recursive regarding $G$ and $y \Elem \Dom(h)$ in $h(y)$'' for $y \Elem \alpha$.
       Then $H'$ is a map from $\alpha$ to $A$.
       We have $H' \Eq H' \FUNrest \alpha$.
       Define \[ H(\beta) =
@@ -83,7 +83,7 @@ all ordinals $\alpha$.
           H'(\beta)                 & : \beta \ORDless \alpha \\
           G(H' \FUNrest \beta)  & : \beta \Eq \alpha
         \end{cases} \]
-      for $\beta \in \ORDsucc(\alpha)$.
+      for $\beta \Elem \ORDsucc(\alpha)$.
       
       Let us show that $H \FUNrest \beta \Elem \ORDfunspace{A}$ for all $\beta \Elem \Dom(H)$.
         Let $\beta \Elem \Dom(H)$.
@@ -133,7 +133,7 @@ all ordinals $\alpha$.
     Consequently every ordinal is contained in the domain of some map $H$ to $A$ such that $H$ is recursive regarding $G$.
   \end{proof}
 
-  Define $F(\alpha) =$ ``choose a map $H$ to $A$ such that $H$ is recursive regarding $G$ and $\alpha \Elem \Dom(H)$ in $H(\alpha)$'' for $\alpha \in \Ord$.
+  Define $F(\alpha) =$ ``choose a map $H$ to $A$ such that $H$ is recursive regarding $G$ and $\alpha \Elem \Dom(H)$ in $H(\alpha)$'' for $\alpha \Elem \Ord$.
   Then $F$ is a map from $\Ord$ to $A$.
 
   $F$ is recursive regarding $G$.
@@ -180,7 +180,7 @@ all ordinals $\alpha$.
 As a corollary of the transfinite recursion theorem we get that we can
 define maps recursively on the ordinals by case distinction:
 For given maps $G \FUNfromto{\Ord \SETprod A}{A}$ and
-$H \FUNfromto{\Ord \SETprod \ORDfunspace{A}}{A}$ and an element $a \in A$ we
+$H \FUNfromto{\Ord \SETprod \ORDfunspace{A}}{A}$ and an element $a \Elem A$ we
 can define a map $F \FUNfromto{\Ord}{A}$ by
 \begin{itemize}
   \item $F(\ORDzero) = a$,
@@ -223,7 +223,7 @@ can define a map $F \FUNfromto{\Ord}{A}$ by
       H(\Dom(f), f)
       & : \text{$\Dom(f)$ is a limit ordinal}
     \end{cases} \]
-  for $f \in \ORDfunspace{A}$.
+  for $f \Elem \ORDfunspace{A}$.
 
   Then $J$ is a map from $\ORDfunspace{A}$ to $A$.
   Indeed we can show that for any $f \Elem \ORDfunspace{A}$ we have $J(f) \Elem A$.

--- a/math/archive/articles/source/zermelo-wellordering.ftl.en.tex
+++ b/math/archive/articles/source/zermelo-wellordering.ftl.en.tex
@@ -31,8 +31,8 @@ denote the collection of all maps $f \FUNfromto{\alpha}{A}$ for some ordinal
 $\alpha$.
 Moreover, for any map $G \FUNfromto{\ORDfunspace{A}}{A}$ we say that a map
 $F \FUNfromto{\Ord}{A}$, where $\Ord$ denotes the class of all ordinals, is
-recursive regarding $G$ if $F(\alpha) = G(F \FUNrest \alpha)$ for all
-$\alpha \in \Ord$.
+recursive regarding $G$ if $F(\alpha) \Eq G(F \FUNrest \alpha)$ for all
+$\alpha \Elem \Ord$.
 
 \begin{theorem}[forthel,title=Zermelo's Well-Ordering Theorem,name=Zermelo]
   Every set is equinumerous to some ordinal.
@@ -52,7 +52,7 @@ $\alpha \in \Ord$.
       x
       & : x \SETdiff \FUNrange(F) \Eq \SETempty
     \end{cases} \]
-  for $F \in \ORDfunspace{A}$.
+  for $F \Elem \ORDfunspace{A}$.
   We can show that for any $F \Elem \ORDfunspace{A}$ if $x \SETdiff \FUNrange(F) \NotEq \SETempty$ then $G(F) \Elem x \SETdiff \FUNrange(F)$.
     Let $F \Elem \ORDfunspace{A}$.
     Assume $x \SETdiff \FUNrange(F) \NotEq \SETempty$.  

--- a/math/archive/libraries/arithmetics/source/dedekind-recursion-theorem.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/dedekind-recursion-theorem.ftl.en.tex
@@ -6,7 +6,9 @@
 \importmodule[libraries/arithmetics]{nat-is-a-set.ftl}
 \importmodule[libraries/set-theory]{zfc.ftl}
 
-\begin{definition}[forthel]
+\symdecl*{recursively defined}
+
+\begin{definition}[forthel,for=recursively defined]
   Let $a$ be an object and $f$ be a map.
   Let $\varphi$ be a map from $\Nat$ to $\Dom(f)$.
   $\varphi$ is \emph{recursively defined by $a$ and $f$} iff $\varphi(\NATzero) = a$ and $\varphi(n \NATplus \NATone) = f(\varphi(n))$ for every $n \Elem \Nat$.

--- a/math/archive/libraries/arithmetics/source/divisibility.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/divisibility.ftl.en.tex
@@ -6,8 +6,14 @@
 \importmodule[libraries/arithmetics]{multiplication-and-ordering.ftl}
 \symdef{NATmid}{\,\mid\,}
 \symdef{NATnmid}{\,\nmid\,}
+\symdecl*{divisible}
+\symdecl*{divide}
+\symdecl*{factor}
+\symdecl*{divisor}
+\symdecl*{trivial divisor}
+\symdecl*{nontrivial divisor}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={divisible,divide}]
   Let $n, m$ be natural numbers.
   $\emph{n \NATmid m}$ iff there exists a natural number $k$ such that $n \NATmul k \Eq m$.
   Let $m$ is \emph{divisible by $n$} stand for $n \NATmid m$.
@@ -20,18 +26,18 @@
   $n$ divides $m$ iff there exists a natural number $k$ such that $k \NATmul n \Eq m$.
 \end{lemma}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={factor,divisor}]
   Let $n$ be a natural number.
   A \emph{factor of $n$} is a natural number that divides $n$.
   Let a \emph{divisor of $n$} stand for a factor of $n$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=trivial divisor]
   Let $n$ be a natural number.
   A \emph{trivial divisor of $n$} is a divisor $m$ of $n$ such that $m \Eq \NATone$ or $m \Eq n$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=nontrivial divisor]
   Let $n$ be a natural number.
   A \emph{nontrivial divisor of $n$} is a divisor $m$ of $n$ such that $m \NotEq \NATone$ and $m \NotEq n$.
 \end{definition}

--- a/math/archive/libraries/arithmetics/source/division.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/division.ftl.en.tex
@@ -5,8 +5,9 @@
 \begin{smodule}{division.ftl}
 \importmodule[libraries/arithmetics]{divisibility.ftl}
 \symdef{NATfrac}[args=2]{\frac{#1}{#2}}
+\symdecl*{quotient}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=quotient]
   Let $n$ be a natural number and $m$ be a nonzero divisor of $n$.
   $\emph{\NATfrac{n}{m}}$ is the natural number $k$ such that $k \NATmul m \Eq n$.
   Let the \emph{quotient of $n$ and $m$} stand for $\NATfrac{n}{m}$.

--- a/math/archive/libraries/arithmetics/source/even-and-odd-numbers.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/even-and-odd-numbers.ftl.en.tex
@@ -5,14 +5,16 @@
 \begin{smodule}{even-and-odd-numbers.ftl}
 \importmodule[libraries/arithmetics]{divisibility.ftl}
 \importmodule[libraries/arithmetics]{subtraction.ftl}
+\symdecl*{even}
+\symdecl*{odd}
 
 \begin{sfragment}{Definition}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=even]
     Let $n$ be a natural number.
     $n$ is \emph{even} iff $n$ is divisible by $\NATtwo$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=odd]
     Let $n$ be a natural number.
     $n$ is \emph{odd} iff $n$ is not divisible by $\NATtwo$.
   \end{definition}

--- a/math/archive/libraries/arithmetics/source/exponentiation.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/exponentiation.ftl.en.tex
@@ -7,17 +7,17 @@
 \symdef{NATexp}[args=2]{{#1}^{#2}}
 
 \begin{sfragment}{Definition}
-  \begin{signature}[forthel]
+  \begin{signature}[forthel,for=NATexp]
     Let $n, m$ be natural numbers.
     $\emph{\NATexp{n}{m}}$ is a natural number.
   \end{signature}
 
-  \begin{axiom}[forthel]
+  \begin{axiom}[forthel,for=NATexp]
     Let $n$ be a natural number.
     Then $\NATexp{n}{\NATzero} \Eq \NATone$.
   \end{axiom}
 
-  \begin{axiom}[forthel]
+  \begin{axiom}[forthel,for=NATexp]
     Let $n, m$ be natural numbers.
     Then $\NATexp{n}{m \NATplus \NATone} \Eq \NATexp{n}{m} \NATmul n$.
   \end{axiom}

--- a/math/archive/libraries/arithmetics/source/factorial.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/factorial.ftl.en.tex
@@ -6,16 +6,16 @@
 \importmodule[libraries/arithmetics]{multiplication.ftl}
 \symdef{NATfac}[args=1]{#1\comp!}
 
-\begin{signature}[forthel]
+\begin{signature}[forthel,for=NATfac]
   Let $n$ be a natural number.
   $\emph{\NATfac{n}}$ is a natural number.
 \end{signature}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=NATfac]
   $\NATfac{\NATzero} \Eq \NATone$.
 \end{axiom}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=NATfac]
   Let $n$ be a natural number.
   Then $\NATfac{n \NATplus \NATone} \Eq \NATfac{n} \NATmul (n \NATplus \NATone)$.
 \end{axiom}

--- a/math/archive/libraries/arithmetics/source/modular-arithmetics.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/modular-arithmetics.ftl.en.tex
@@ -7,15 +7,18 @@
 \symdef{NATdiv}{\,\textrm{div}\,}
 \symdef{NATmod}{\,\textrm{mod}\,}
 \symdef{NATcong}[args=3]{#1\mathrel{\comp\equiv}#2\;\comp{(\textrm{mod}}\,#3\comp)}
+\symdecl*{quotient}
+\symdecl*{remainder}
+\symdecl*{congruent}
 
 \begin{sfragment}{Quotients and Remainders}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=quotient]
     Let $n, m$ be natural numbers such that $m \NotEq \NATzero$.
     $\emph{n \NATdiv m}$ is the natural number $q$ such that $n \Eq (m \NATmul q) \NATplus r$ for some natural number $r$ that is less than $m$.
     Let the \emph{quotient of $n$ over $m$} stand for $n \NATdiv m$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=remainder]
     Let $n, m$ be natural numbers such that $m \NotEq \NATzero$.
     $\emph{n \NATmod m}$ is the natural number $r$ such that $r \NATless m$ and there exists a natural number $q$ such that $n \Eq (m \NATmul q) \NATplus r$.
     Let the \emph{remainder of $n$ over $m$} stand for $n \NATmod m$.
@@ -23,7 +26,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Basic Properties}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=congruent]
     Let $n, m, k$ be natural numbers such that $k \NotEq \NATzero$.
     $\emph{\NATcong{n}{m}{k}}$ iff $n \NATmod k \Eq m \NATmod k$.
     Let $n$ and $m$ are \emph{congruent modulo $k$} stand for $\NATcong{n}{m}{k}$.

--- a/math/archive/libraries/arithmetics/source/multiplication.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/multiplication.ftl.en.tex
@@ -4,21 +4,21 @@
 \begin{document}
 \begin{smodule}{multiplication.ftl}
 \importmodule[libraries/arithmetics]{natural-numbers.ftl}
-\symdef{NATmul}{\,\cdot\,}
+\symdef{NATmul}[name=product]{\,\cdot\,}
 
 \begin{sfragment}{Definition}
-  \begin{signature}[forthel]
+  \begin{signature}[forthel,for=NATmul]
     Let $n, m$ be natural numbers.
     $\emph{n \NATmul m}$ is a natural number.
     Let the \emph{product of $n$ and $m$} stand for $n \NATmul m$.
   \end{signature}
 
-  \begin{axiom}[forthel]
+  \begin{axiom}[forthel,for=NATmul]
     Let $n$ be a natural number.
     Then $n \NATmul \NATzero \Eq \NATzero$.
   \end{axiom}
 
-  \begin{axiom}[forthel]
+  \begin{axiom}[forthel,for=NATmul]
     Let $n, m$ be natural numbers.
     Then $n \NATmul (m \NATplus \NATone) \Eq (n \NATmul m) \NATplus n$.
   \end{axiom}

--- a/math/archive/libraries/arithmetics/source/natural-numbers.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/natural-numbers.ftl.en.tex
@@ -5,81 +5,84 @@
 \begin{smodule}{natural-numbers.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
 \symdef{Nat}{\mathbb N}
-\symdef{NATplus}{\,+\,}
-\symdef{NATzero}{0}
-\symdef{NATone}{1}
-\symdef{NATtwo}{2}
-\symdef{NATthree}{3}
-\symdef{NATfour}{4}
-\symdef{NATfive}{5}
-\symdef{NATsix}{6}
-\symdef{NATseven}{7}
-\symdef{NATeight}{8}
-\symdef{NATnine}{9}
+\symdef{NATplus}[name=sum]{\,+\,}
+\symdef{NATzero}[name=zero]{0}
+\symdef{NATone}[name=one]{1}
+\symdef{NATtwo}[name=two]{2}
+\symdef{NATthree}[name=three]{3}
+\symdef{NATfour}[name=four]{4}
+\symdef{NATfive}[name=five]{5}
+\symdef{NATsix}[name=six]{6}
+\symdef{NATseven}[name=seven]{7}
+\symdef{NATeight}[name=eight]{8}
+\symdef{NATnine}[name=nine]{9}
+\symdecl*{natural number}
+\symdecl*{nonzero}
+\symdecl*{direct successor}
 
 \begin{sfragment}{The Language of Natural Number Arithmetic}
-  \begin{signature}[forthel]
+  \begin{signature}[forthel,for=natural number]
     A \emph{natural number} is an object.
   \end{signature}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=Nat]
     $\emph{\Nat}$ is the class of natural numbers.
   \end{definition}
 
-  \begin{signature}[forthel]
+  \begin{signature}[forthel,for=sum]
     Let $n, m$ be natural numbers.
     $\emph{n \NATplus m}$ is a natural number.
     Let the \emph{sum of $n$ and $m$} stand for $n \NATplus m$.
   \end{signature}
 
-  \begin{signature}[forthel]
+  \begin{signature}[forthel,for={zero,nonzero}]
     $\emph{\NATzero}$ is a natural number.
     Let \emph{zero} stand for $\NATzero$.
     Let $n$ is \emph{nonzero} stand for $n \NotEq \NATzero$.
   \end{signature}
 
-  \begin{signature}[forthel]
+  \begin{signature}[forthel,for={one,direct successor}]
     $\emph{\NATone}$ is a natural number.
     Let \emph{one} stand for $\NATone$.
     Let the \emph{direct successor of $n$} stand for $n \NATplus \NATone$.
   \end{signature}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=two]
     $\emph{\NATtwo} = \NATone \NATplus \NATone$.
     Let \emph{two} stand for $\NATtwo$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=three]
     $\emph{\NATthree} = \NATtwo \NATplus \NATone$.
     Let \emph{three} stand for $\NATthree$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=four]
     $\emph{\NATfour} = \NATthree \NATplus \NATone$.
     Let \emph{four} stand for $\NATfour$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=five]
     $\emph{\NATfive} = \NATfour \NATplus \NATone$.
     Let \emph{five} stand for $\NATfive$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=six]
     $\emph{\NATsix} = \NATfive \NATplus \NATone$.
     Let \emph{six} stand for $\NATsix$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=seven]
     $\emph{\NATseven} = \NATsix \NATplus \NATone$.
     Let \emph{seven} stand for $\NATseven$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=eight]
     $\emph{\NATeight} = \NATseven \NATplus \NATone$.
     Let \emph{eight} stand for $\NATeight$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=nine]
     $\emph{\NATnine} = \NATeight \NATplus \NATone$.
     Let \emph{nine} stand for $\NATnine$.
   \end{definition}

--- a/math/archive/libraries/arithmetics/source/ordering.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/ordering.ftl.en.tex
@@ -4,9 +4,9 @@
 \begin{document}
 \begin{smodule}{ordering.ftl}
 \importmodule[libraries/arithmetics]{natural-numbers.ftl}
-\symdef{NATless}{\;<\;}
+\symdef{NATless}[name=less]{\;<\;}
 \symdef{NATnless}{\;\not<\;}
-\symdef{NATgtr}{\;>\;}
+\symdef{NATgtr}[name=greater]{\;>\;}
 \symdef{NATngtr}{\;\not>\;}
 \symdef{NATleq}{\;\leq\;}
 \symdef{NATnleq}{\;\not\leq\;}
@@ -16,9 +16,12 @@
 \symdef{Natgtrthan}[args=1]{\comp[\mathbb{N}]_{\comp>#1}}
 \symdef{Natleqthan}[args=1]{\comp{\mathbb{N}}_{\comp\leq#1}}
 \symdef{Natgeqthan}[args=1]{\comp{\mathbb{N}}_{\comp\geq#1}}
+\symdecl*{positive}
+\symdecl*{predecessor}
+\symdecl*{successor}
 
 \begin{sfragment}{Definitions and Immediate Consequences}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={less,NATnless,greater,NATngtr}]
     Let $n, m$ be natural numbers.
     $\emph{n \NATless m}$ iff there exists a nonzero natural number $k$ such that $m \Eq n \NATplus k$.
     Let $n$ is \emph{less than $m$} stand for $n \NATless m$.
@@ -28,22 +31,22 @@
     Let $\emph{n \NATngtr m}$ stand for $n$ is not greater than $m$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=Natlessthan]
     Let $n$ be a natural number.
     $\emph{\Natlessthan{n}} = \SClass{k}{\Nat}{k \NATless n}$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=Natgtrthan]
     Let $n$ be a natural number.
     $\emph{\Natgtrthan{n}} = \SClass{k}{\Nat}{k \NATgtr n}$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=positive]
     Let $n$ be a natural number.
     $n$ is \emph{positive} iff $n \NATgtr \NATzero$.
 \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={NATleq,NATgeq,NATnleq,NATngeq}]
     Let $n, m$ be natural numbers.
     $\emph{n \NATleq m}$ iff there exists a natural number $k$ such that $m \Eq n \NATplus k$.
     Let $n$ is \emph{less than or equal to $m$} stand for $n \NATleq m$.
@@ -53,12 +56,12 @@
     Let $\emph{n \NATngeq m}$ stand for $n$ is not greater than or equal to $m$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=Natleqthan]
     Let $n$ be a natural number.
     $\emph{\Natleqthan{n}} = \SClass{k}{\Nat}{k \NATleq n}$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=Natgeqthan]
     Let $n$ be a natural number.
     $\emph{\Natgeqthan{n}} = \SClass{k}{\Nat}{k \NATgeq n }$.
   \end{definition}
@@ -80,12 +83,12 @@
     \end{case}
   \end{proof}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=predecessor]
     Let $n$ be a natural number.
     A \emph{predecessor of $n$} is a natural number that is less than $n$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=successor]
     Let $n$ be a natural number.
     A \emph{successor of $n$} is a natural number that is greater than $n$.
   \end{definition}

--- a/math/archive/libraries/arithmetics/source/primes.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/primes.ftl.en.tex
@@ -7,15 +7,21 @@
 \importmodule[libraries/arithmetics]{modular-arithmetics.ftl}
 \importmodule[libraries/arithmetics]{euclid-division-theorem.ftl}
 \symdef{Prime}{\mathbb P}
+\symdecl*{prime}
+\symdecl*{compound}
+\symdecl*{prime number}
+\symdecl*{coprime}
+\symdecl*{relatively prime}
+\symdecl*{mutually prime}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={prime,compound,prime number}]
   Let $n$ be a natural number.
   $n$ is \emph{prime} iff $n \NATgtr \NATone$ and $n$ has no nontrivial divisors.
   Let $n$ is \emph{compound} stand for $n$ is not prime.
   Let a \emph{prime number} stand for a natural number that is prime.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=Prime]
   $\emph{\Prime}$ is the class of all prime numbers.
 \end{definition}
 
@@ -55,7 +61,7 @@
   Thus every natural number belongs to $\Phi$ (by \sr{induction II}{induction}).
 \end{proof}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={coprime,relatively prime,mutually prime}]
   Let $n, m$ be natural numbers.
   $n$ and $m$ are \emph{coprime} iff for all nonzero natural numbers $k$ such that $k \NATmid n$ and $k \NATmid m$ we have $k \Eq \NATone$.
   Let $n$ and $m$ are \emph{relatively prime} stand for $n$ and $m$ are coprime.

--- a/math/archive/libraries/arithmetics/source/subtraction.ftl.en.tex
+++ b/math/archive/libraries/arithmetics/source/subtraction.ftl.en.tex
@@ -4,9 +4,9 @@
 \begin{document}
 \begin{smodule}{subtraction.ftl}
 \importmodule[libraries/arithmetics]{ordering.ftl}
-\symdef{NATsub}{\,-\,}
+\symdef{NATsub}[name=difference]{\,-\,}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=difference]
   Let $n, m$ be natural numbers such that $n \NATgeq m$.
   $\emph{n \NATsub m}$ is the natural number $k$ such that $n \Eq m \NATplus k$.
   Let the \emph{difference of $n$ and $m$} stand for $n \NATsub m$.

--- a/math/archive/libraries/everyday-ontology/source/actions/shave.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/actions/shave.ftl.en.tex
@@ -4,10 +4,11 @@
 \begin{smodule}{shave.ftl}
   \importmodule[libraries/everyday-ontology]{classes?being.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{shave}
+
+  \begin{signature}[forthel,for=shave]
     Let $B,B'$ be beings.
     $B$ \emph{shaves $B'$} is a relation.
-
     Let $B$ shaves himself stand for $B$ shaves $B$.
     Let $B$ shaves herself stand for $B$ shaves $B$.
     Let $B$ shaves themselves stand for $B$ shaves $B$.

--- a/math/archive/libraries/everyday-ontology/source/classes/animal.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/classes/animal.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{animal.ftl}
   \importmodule[libraries/everyday-ontology]{classes?being.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{animal}
+
+  \begin{signature}[forthel,for=animal]
     A \emph{animal} is a being.
   \end{signature}
 \end{smodule}

--- a/math/archive/libraries/everyday-ontology/source/classes/being.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/classes/being.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{being.ftl}
   \importmodule[libraries/meta]{preliminaries.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{being}
+
+  \begin{signature}[forthel,for=being]
     A \emph{being} is an object.
   \end{signature}
 \end{smodule}

--- a/math/archive/libraries/everyday-ontology/source/classes/human.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/classes/human.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{human.ftl}
   \importmodule[libraries/everyday-ontology]{properties?human.ftl}
 
-  \begin{definition}[forthel]
+  \symdecl*{human}
+
+  \begin{definition}[forthel,for=human]
     A \emph{human} is a human being $B$.
     % We need the variable $B$ because of the bug describen in
     % <https://github.com/naproche/naproche/issues/23>.

--- a/math/archive/libraries/everyday-ontology/source/classes/person.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/classes/person.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{person.ftl}
   \importmodule[libraries/everyday-ontology]{classes?being.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{person}
+
+  \begin{signature}[forthel,for=person]
     A \emph{person} is a being.
   \end{signature}
 \end{smodule}

--- a/math/archive/libraries/everyday-ontology/source/classes/place.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/classes/place.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{place.ftl}
   \importmodule[libraries/meta]{preliminaries.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{place}
+
+  \begin{signature}[forthel,for=place]
     A \emph{place} is an object.
   \end{signature}
 \end{smodule}

--- a/math/archive/libraries/everyday-ontology/source/individuals/socrates.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/individuals/socrates.ftl.en.tex
@@ -3,8 +3,10 @@
 \begin{document}
 \begin{smodule}{socrates.ftl}
   \importmodule[libraries/everyday-ontology]{classes?human.ftl}
+
+  \symdecl*{Socrates}
   
-  \begin{signature}[forthel]
+  \begin{signature}[forthel,for=Socrates]
     \emph{Socrates} is a human.
   \end{signature}
 \end{smodule}

--- a/math/archive/libraries/everyday-ontology/source/properties/drinking.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/properties/drinking.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{drinking.ftl}
   \importmodule[libraries/everyday-ontology]{classes?being.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{drinking}
+
+  \begin{signature}[forthel,for=drinking]
     Let $B$ be a being.
     $B$ is \emph{drinking} is a relation.
   \end{signature}

--- a/math/archive/libraries/everyday-ontology/source/properties/human.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/properties/human.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{human.ftl}
   \importmodule[libraries/everyday-ontology]{classes?being.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{human}
+
+  \begin{signature}[forthel,for=human]
     Let $B$ be a being.
     $B$ is \emph{human} is a relation.
   \end{signature}

--- a/math/archive/libraries/everyday-ontology/source/properties/inside.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/properties/inside.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{inside.ftl}
   \importmodule[libraries/everyday-ontology]{classes?place.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{inside}
+
+  \begin{signature}[forthel,for=inside]
     Let $x$ be an object and $P$ be a place.
     $x$ is \emph{inside $P$} is a relation.
   \end{signature}

--- a/math/archive/libraries/everyday-ontology/source/properties/mortal.ftl.en.tex
+++ b/math/archive/libraries/everyday-ontology/source/properties/mortal.ftl.en.tex
@@ -4,7 +4,9 @@
 \begin{smodule}{mortal.ftl}
   \importmodule[libraries/everyday-ontology]{classes?being.ftl}
 
-  \begin{signature}[forthel]
+  \symdecl*{mortal}
+
+  \begin{signature}[forthel,for=mortal]
     Let $B$ be a being.
     $B$ is \emph{mortal} is a relation.
   \end{signature}

--- a/math/archive/libraries/foundations/source/choice-maps.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/choice-maps.ftl.en.tex
@@ -5,8 +5,9 @@
 \begin{smodule}{choice-maps.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{maps.ftl}
+\symdecl*{choice map}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=choice map]
   Let $X$ be a system of nonempty sets.
   A \emph{choice map for $X$} is a map $g$ such that $\Dom(g) \Eq X$ and $g(x) \Elem x$ for any $x \Elem X$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/classes.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/classes.ftl.en.tex
@@ -17,9 +17,23 @@
 \symdef{SETunion}{\,\cup\,}
 \symdef{SETintersect}{\,\cap\,}
 \symdef{SETdiff}{\,\setminus\,}
+\symdecl*{subclass}
+\symdecl*{superclass}
+\symdecl*{proper subclass}
+\symdecl*{proper superclass}
+\symdecl*{include}
+\symdecl*{empty}
+\symdecl*{nonempty}
+\symdecl*{unordered pair}
+\symdecl*{singleton class}
+\symdecl*{unique element}
+\symdecl*{union}
+\symdecl*{intersection}
+\symdecl*{complement}
+\symdecl*{disjoint}
 
 \begin{sfragment}{Sub- and Superclasses}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={subclass,SETinclude,superclass,SETniclude,proper subclass,SETstrictinclude,proper superclass,SETstrictniclude,include}]
     Let $A$ be a class.
     A \emph{subclass of $A$} is a class $B$ such that every element of $B$ is an
     element of $A$.
@@ -66,13 +80,13 @@
 \end{sfragment}
 
 \begin{sfragment}{The Empty Class}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={empty,nonempty}]
     Let $A$ be a class.
     $A$ is \emph{empty} iff $A$ has no elements.
     Let $A$ is \emph{nonempty} stand for $A$ is not empty.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=SETempty]
     $\emph{\SETempty} = \CClass{x}{x \NotEq x}$.
   \end{definition}
 
@@ -104,23 +118,23 @@
 \end{sfragment}
 
 \begin{sfragment}{Unordered Pairs}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={SETpair,unordered pair}]
     Let $a, b$ be objects.
     $\emph{\SETpair{a}{b}} = \CClass{x}{x \Eq a\text{ or }x \Eq b}$.
     Let the \emph{unordered pair of $a$ and $b$} stand for $\SETpair{a}{b}$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=unordered pair]
     An \emph{unordered pair} is a class $A$ such that $A \Eq \SETpair{a}{b}$ for some distinct objects $a, b$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={SETsingleton,singleton class}]
     Let $a$ be an object.
     $\emph{\SETsingleton{a}} = \CClass{x}{x \Eq a}$.
     Let the \emph{singleton class of $a$} stand for $\SETsingleton{a}$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=singleton class]
     A \emph{singleton class} is a class $A$ such that $A \Eq \SETsingleton{a}$ for some object $a$.
   \end{definition}
 
@@ -141,7 +155,7 @@
     If $\SETsingleton{a} \Eq \SETsingleton{a'}$ then $a \Eq a'$.
   \end{corollary}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=unique element]
     Let $A$ be a class.
     A \emph{unique element of $A$} is an element $a$ of $A$ such that for each $x \Elem A$ we have $x \Eq a$.
   \end{definition}
@@ -153,19 +167,19 @@
 \end{sfragment}
 
 \begin{sfragment}{Unions, Intersections, Complements}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={SETunion,union}]
     Let $A, B$ be classes.
     $\emph{A \SETunion B} = \CClass{x}{x \Elem A\text{ or }x \Elem B}$.
     Let the \emph{union of $A$ and $B$} stand for $A \SETunion B$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={SETintersect,intersection}]
     Let $A, B$ be classes.
     $\emph{A \SETintersect B} = \CClass{x}{x \Elem A\text{ and }x \Elem B}$.
     Let the \emph{intersection of $A$ and $B$} stand for $A \SETintersect B$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={SETdiff,complement}]
     Let $A, B$ be classes.
     $\emph{A \SETdiff B} = \CClass{x}{x \Elem A\text{ and }x \NotElem B}$.
     Let the \emph{complement of $B$ in $A$} stand for $A \SETdiff B$.
@@ -173,7 +187,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Disjoint Classes}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=disjoint]
     Let $A, B$ be classes.
     $A$ and $B$ are \emph{disjoint} iff $A$ and $B$ have no common elements.
   \end{definition}

--- a/math/archive/libraries/foundations/source/closure-under-arbitrary-intersections.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/closure-under-arbitrary-intersections.ftl.en.tex
@@ -4,8 +4,10 @@
 \begin{document}
 \begin{smodule}{closure-under-arbitrary-intersections.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
+\symdecl*{closed under arbitrary intersections}
+\symdecl*{closed under intersections}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={closed under arbitrary intersections,closed under intersections}]
   Let $X$ be a system of sets.
   $X$ is \emph{closed under arbitrary intersections} iff $\SETintersectover U \Elem X$ for every nonempty subclass $U$ of $X$.
   Let $X$ is \emph{closed under intersections} stand for $X$ is closed under arbitrary intersections.

--- a/math/archive/libraries/foundations/source/closure-under-arbitrary-unions.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/closure-under-arbitrary-unions.ftl.en.tex
@@ -4,8 +4,10 @@
 \begin{document}
 \begin{smodule}{closure-under-arbitrary-unions.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
+\symdecl*{closed under arbitrary unions}
+\symdecl*{closed under unions}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={closed under arbitrary unions,closed under unions}]
   Let $X$ be a system of sets.
   $X$ is \emph{closed under arbitrary unions} iff $\SETunionover U \Elem X$ for every  subclass $U$ of $X$.
   Let $X$ is \emph{closed under unions} stand for $X$ is closed under arbitrary unions.

--- a/math/archive/libraries/foundations/source/closure-under-countable-intersections.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/closure-under-countable-intersections.ftl.en.tex
@@ -5,8 +5,9 @@
 \begin{smodule}{closure-under-countable-intersections.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{countable-and-uncountable-classes.ftl}
+\symdecl*{closed under countable intersections}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=closed under countable intersections]
   Let $X$ be a system of sets.
   $X$ is \emph{closed under countable intersections} iff $\SETintersectover U \Elem X$ for every nonempty countable subclass $U$ of $X$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/closure-under-countable-unions.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/closure-under-countable-unions.ftl.en.tex
@@ -5,8 +5,9 @@
 \begin{smodule}{closure-under-countable-unions.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{countable-and-uncountable-classes.ftl}
+\symdecl*{closed under countable unions}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={closed under countable unions}]
   Let $X$ be a system of sets.
   $X$ is \emph{closed under countable unions} iff $\SETunionover U \Elem X$ for every nonempty countable subclass $U$ of $ X$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/closure-under-finite-intersections.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/closure-under-finite-intersections.ftl.en.tex
@@ -5,8 +5,9 @@
 \begin{smodule}{closure-under-finite-intersections.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{finite-and-infinite-classes.ftl}
+\symdecl*{closed under finite intersections}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=closed under finite intersections]
   Let $X$ be a system of sets.
   $X$ is \emph{closed under finite intersections} iff $\SETintersectover U \Elem X$ for every nonempty finite subclass $U$ of $X$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/closure-under-finite-unions.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/closure-under-finite-unions.ftl.en.tex
@@ -5,8 +5,9 @@
 \begin{smodule}{closure-under-finite-unions.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{finite-and-infinite-classes.ftl}
+\symdecl*{closed under finite unions}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=closed under finite unions]
   Let $X$ be a system of sets.
   $X$ is \emph{closed under finite unions} iff $\SETunionover U \Elem X$ for every nonempty finite subclass $U$ of $X$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/closure-under-powersets.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/closure-under-powersets.ftl.en.tex
@@ -4,8 +4,9 @@
 \begin{document}
 \begin{smodule}{closure-under-powersets.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
+\symdecl*{closed under powersets}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=closed under powersets]
   Let $X$ be a system of sets.
   $X$ is \emph{closed under powersets} iff $\SETpow(U) \Elem X$ for every $U \Elem X$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/constant-maps.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/constant-maps.ftl.en.tex
@@ -5,13 +5,14 @@
 \begin{smodule}{constant-maps.ftl}
 \importmodule[libraries/foundations]{injections-surjections-bijections.ftl}
 \symdef{FUNconst}[args=2]{\textrm{const}_{#1}^{#2}}
+\symdecl*{constant}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=constant]
   Let $f$ be a map.
   $f$ is \emph{constant} iff there exists an object $a$ such that $f(x) \Eq a$ for all $x \Elem \Dom(f)$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=FUNconst]
   Let $A$ be a class and $a$ be an object.
   $\emph{\FUNconst{A}{a}}$ is the map $f$ such that $\Dom(f) \Eq A$ and $f(x) \Eq a$ for all $x \Elem A$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/countable-and-uncountable-classes.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/countable-and-uncountable-classes.ftl.en.tex
@@ -4,9 +4,12 @@
 \begin{document}
 \begin{smodule}{countable-and-uncountable-classes.ftl}
 \importmodule[libraries/foundations]{finite-and-infinite-classes.ftl}
+\symdecl*{countably infinite}
+\symdecl*{countable}
+\symdecl*{uncountable}
 
 \begin{sfragment}{Countably Infinite Classes}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=countably infinite]
     Let $X$ be a class.
     $X$ is \emph{countably infinite} iff $X$ is equinumerous to $\Nat$.
   \end{definition}
@@ -25,7 +28,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Countable Classes}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=countable]
     Let $X$ be a class.
     $X$ is \emph{countable} iff $X$ is finite or $X$ is countably infinite.
   \end{definition}
@@ -43,7 +46,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Uncountable Classes}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=uncountable]
     Let $X$ be a class.
     $X$ is \emph{uncountable} iff $X$ is not countable.
   \end{definition}

--- a/math/archive/libraries/foundations/source/equinumerosity.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/equinumerosity.ftl.en.tex
@@ -4,8 +4,9 @@
 \begin{document}
 \begin{smodule}{equinumerosity.ftl}
 \importmodule[libraries/foundations]{invertible-maps.ftl}
+\symdecl*{equinumerous}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=equinumerous]
   Let $A, B$ be classes.
   $A$ is \emph{equinumerous to $B$} iff there exists a bijection between $A$ and $B$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/finite-and-infinite-classes.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/finite-and-infinite-classes.ftl.en.tex
@@ -5,6 +5,8 @@
 \begin{smodule}{finite-and-infinite-classes.ftl}
 \importmodule[libraries/foundations]{segments-of-natural-numbers.ftl}
 \importmodule[libraries/foundations]{equinumerosity.ftl}
+\symdecl*{finite}
+\symdecl*{infinite}
 
 \begin{sfragment}{Finite Classes}
   \begin{definition}[forthel]
@@ -12,7 +14,7 @@
     $X$ \emph{has $n$ elements} iff $X$ is equinumerous to $\NATsegment{\NATone}{n}$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=finite]
     Let $X$ be a class.
     $X$ is \emph{finite} iff there exists a natural number $n$ such that $X$ has $n$ elements.
   \end{definition}
@@ -129,7 +131,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Infinite Classes}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=infinite]
     Let $X$ be a class.
     $X$ is \emph{infinite} iff $X$ is not finite.
   \end{definition}

--- a/math/archive/libraries/foundations/source/injections-surjections-bijections.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/injections-surjections-bijections.ftl.en.tex
@@ -6,16 +6,20 @@
 \importmodule[libraries/foundations]{maps.ftl}
 \symdef{FUNfromonto}[args=2]{\mathbin{\comp:}#1\mathbin{\comp\twoheadrightarrow}#2}
 \symdef{FUNfrominto}[args=2]{\mathbin{\comp:}#1\mathbin{\comp\hookrightarrow}#2}
+\symdecl*{surjective}
+\symdecl*{injective}
+\symdecl*{bijection}
+\symdecl*{permutation}
 
 \begin{sfragment}{Surjective Maps}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=surjective]
     Let $f$ be a map and $B$ be a class.
     $f$ is \emph{surjective onto $B$} iff $\FUNrange(f) \Eq B$.
     Let $f$ \emph{surjects onto $B$} stand for $f$ is surjective onto $B$.
     Let a \emph{surjective map onto $B$} stand for a map that is surjective onto $B$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={surjective,FUNfromonto}]
     Let $A, B$ be classes.
     A \emph{surjective map from $A$ to $B$} is a map of $A$ that is surjective onto $B$.
     Let a \emph{surjective map from $A$ onto $B$} stand for a surjective map from $A$ to $B$.
@@ -51,7 +55,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Injective Maps}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={injective,FUNfrominto}]
     Let $f$ be a map.
     $f$ is \emph{injective} iff for all $a, a' \Elem \Dom(f)$ if $f(a) \Eq f(a')$ then $a \Eq a'$.
     Let $\emph{f \FUNfrominto{A}{B}}$ stand for $f$ is an injective map from $A$ to $B$.
@@ -59,7 +63,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Bijective Maps}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=bijection]
     Let $A, B$ be classes.
     A \emph{bijection between $A$ and $B$} is an injective map from $A$ to $B$ that is surjective onto $B$.
     Let a \emph{bijection from $A$ to $B$} stand for a bijection between $A$ and $B$.
@@ -74,7 +78,7 @@
     Hence $f$ is a bijection between $A$ and $\FUNrange(f)$.
   \end{proof}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=permutation]
     Let $A$ be a class.
     A \emph{permutation of $A$} is a bijection between $A$ and $A$.
   \end{definition}

--- a/math/archive/libraries/foundations/source/invertible-maps.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/invertible-maps.ftl.en.tex
@@ -5,14 +5,19 @@
 \begin{smodule}{invertible-maps.ftl}
 \importmodule[libraries/foundations]{injections-surjections-bijections.ftl}
 \symdef{FUNinv}[args=1]{#1^{\comp{-1}}}
+\symdecl*{inverse}
+\symdecl*{invertible}
+\symdecl*{involutory}
+\symdecl*{selfinverse}
+\symdecl*{involution}
 
 \begin{sfragment}{Definitions}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=inverse]
     Let $f$ be a map.
     An \emph{inverse of $f$} is a map $g$ from $\FUNrange(f)$ to $\Dom(f)$ such that $f(a) \Eq b \Iff g(b) \Eq a$ for all $a \Elem \Dom(f)$ and all $b \Elem \Dom(g)$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=invertible]
     Let $f$ be a map.
     $f$ is \emph{invertible} iff $f$ has an inverse.
   \end{definition}
@@ -33,7 +38,7 @@
     End.
   \end{proof}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={FUNinv,involutory,selfinverse}]
     Let $f$ be an invertible map.
     $\emph{\FUNinv{f}}$ is the inverse of $f$.
     Let $f$ is \emph{involutory} stand for $f$ is the inverse of $f$.
@@ -317,7 +322,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Involutions}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=involution]
     Let $A$ be a class.
     An \emph{involution on $A$} is a selfinverse map $f$ on $A$.
   \end{definition}

--- a/math/archive/libraries/foundations/source/maps-and-systems-of-sets.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/maps-and-systems-of-sets.ftl.en.tex
@@ -5,12 +5,15 @@
 \begin{smodule}{maps-and-systems-of-sets.ftl}
 \importmodule[libraries/foundations]{maps.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
+\symdecl*{map between systems of sets}
+\symdecl*{subset preserving}
+\symdecl*{preserve subsets}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=map between systems of sets]
   A \emph{map between systems of sets} is a map from some system of sets to some system of sets.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={subset preserving,preserve subsets}]
   Let $f$ be a map between systems of sets.
   $f$ is \emph{subset preserving} iff $x \SETinclude y \Implies f(x) \SETinclude f(y)$ for all $x, y \Elem \Dom(f)$.
   Let $f$ \emph{preserves subsets} stand for $f$ is subset preserving.

--- a/math/archive/libraries/foundations/source/maps.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/maps.ftl.en.tex
@@ -4,26 +4,30 @@
 \begin{document}
 \begin{smodule}{maps.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
-\symdef{FUNid}[args=1]{\comp{\textrm{id}}_{#1}}
-\symdef{FUNrange}{\textrm{range}}
-\symdef{FUNcomp}{\,\circ\,}
-\symdef{FUNrest}{\,\restriction\,}
-\symdef{FUNim}[args=2]{#1\comp[#2\comp]}
+\symdef{FUNid}[name=identity map,args=1]{\comp{\textrm{id}}_{#1}}
+\symdef{FUNrange}[name=range]{\textrm{range}}
+\symdef{FUNcomp}[name=composition]{\,\circ\,}
+\symdef{FUNrest}[name=restriction]{\,\restriction\,}
+\symdef{FUNim}[name=image,args=2]{#1\comp[#2\comp]}
 \notation{FUNim}[parens]{#1\dobrackets{#2}}
 \notation{FUNim}[star]{#1_{\comp*}\dobrackets{#2}}
-\symdef{FUNpreim}[args=2]{#1^{\comp{-1}}\comp[#2\comp]}
+\symdef{FUNpreim}[name=preimage,args=2]{#1^{\comp{-1}}\comp[#2\comp]}
 \notation{FUNpreim}[parens]{#1^{\comp{-1}}\dobrackets{#2}}
 \notation{FUNpreim}[star]{#1^{\comp*}\dobrackets{#2}}
 \symdef{FUNfromto}[args=2]{\mathbin{\comp:}#1\mathbin{\comp\rightarrow}#2}
 \symdef{FUNfunspace}[args=2]{\comp[#1\mathbin{\comp\rightarrow}#2\comp]}
+\symdecl*{value}
+\symdecl*{direct image}
+\symdecl*{inverse image}
+\symdecl*{fixed point}
 
 \begin{sfragment}{Range}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=value]
     Let $f$ be a map.
     A \emph{value of $f$} is an object $b$ such that $b \Eq f(a)$ for some $a \Elem \Dom(f)$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={range}]
     Let $f$ be a map.
     $\emph{\FUNrange(f)} = \CClass{f(a)}{a \Elem \Dom(f)}$.
     Let the \emph{range of $f$} stand for $\FUNrange(f)$.
@@ -48,7 +52,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Identity Map}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={identity map}]
     Let $A$ be a class.
     $\emph{\FUNid{A}}$ is the map defined on $A$ such that $\FUNid{A}(a) \Eq a$ for all $a \Elem A$.
     Let the \emph{identity map on $A$} stand for $\FUNid{A}$.
@@ -56,7 +60,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Composition}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=composition]
     Let $f, g$ be maps.
     Assume $\FUNrange(f) \SETinclude \Dom(g)$.
     $\emph{g \FUNcomp f}$ is the map defined on $\Dom(f)$ such that $(g \FUNcomp f)(a) \Eq g(f(a))$ for all $a \Elem \Dom(f)$.
@@ -65,7 +69,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Restriction}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=restriction]
     Let $f$ be a map and $X \SETinclude \Dom(f)$.
     $\emph{f \FUNrest X}$ is the map defined on $X$ such that $(f \FUNrest X)(a) \Eq f(a)$ for all $a \Elem X$.
     Let the \emph{restriction of $f$ to $X$} stand for $f \FUNrest X$.
@@ -78,14 +82,14 @@
 \end{sfragment}
 
 \begin{sfragment}{Image and Preimage}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={FUNim,image,direct image}]
     Let $f$ be a map and $A$ be a class.
     $\emph{\FUNim{f}{A}} = \CClass{f(a)}{a \Elem \Dom(f) \SETintersect A}$.
     Let the \emph{image of $A$ under $f$} stand for $\FUNim{f}{A}$.
     Let the \emph{direct image of $A$ under $f$} stand for $\FUNim{f}{A}$.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={preimage,inverse image}]
     Let $f$ be a map and $B$ be a class.
     $\emph{\FUNpreim{f}{B}} = \SClass{a}{\Dom(f)}{f(a) \Elem B}$.
     Let the \emph{preimage of $B$ under $f$} stand for $\FUNpreim{f}{B}$.
@@ -94,26 +98,26 @@
 \end{sfragment}
 
 \begin{sfragment}{Maps Between Classes}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={map,function}]
     Let $A$ be a class.
     A \emph{map of $A$} is a map $f$ such that $\Dom(f) \Eq A$.
     Let a \emph{function of $A$} stand for a map of $A$ that is a function.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={map,function}]
     Let $B$ be a class.
     A \emph{map to $B$} is a map $f$ such that $f(a) \Elem B$ for each $a \Elem \Dom(f)$.
     Let a \emph{function to $B$} stand for a map to $B$ that is a function.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={map,FUNfromto,function}]
     Let $A, B$ be classes.
     A \emph{map from $A$ to $B$} is a map $f$ such that $\Dom(f) \Eq A$ and $f(a) \Elem B$ for each $a \Elem A$.
     Let $\emph{f \FUNfromto{A}{B}}$ stand for $f$ is a map from $A$ to $B$.
     Let a \emph{function from $A$ to $B$} stand for a map from $A$ to $B$ that is a function.
   \end{definition}
 
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={map,function}]
     Let $A$ be a class.
     A \emph{map on $A$} is a map from $A$ to $A$.
     Let a \emph{function on $A$} stand for a map on $A$ that is a function.
@@ -200,14 +204,14 @@
 \end{sfragment}
 
 \begin{sfragment}{Classes of Functions}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=FUNfunspace]
     Let $A, B$ be classes.
     $\emph{\FUNfunspace{A}{B}}$ is the class of all functions from $A$ to $B$.
   \end{definition}
 \end{sfragment}
 
 \begin{sfragment}{Fixed Points}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=fixed point]
     Let $f$ be a map.
     A \emph{fixed point of $f$} is an element $x$ of $\Dom(f)$ such that $f(x) \Eq x$.
   \end{definition}

--- a/math/archive/libraries/foundations/source/pairs-and-products.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/pairs-and-products.ftl.en.tex
@@ -5,16 +5,19 @@
 \begin{smodule}{pairs-and-products.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
 \symdef{SETprod}{\,\times\,}
+\symdecl*{ordered pai}
+\symdecl*{Cartesian product}
+\symdecl*{direct product}
 
 \begin{sfragment}{Pairs}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=ordered pair]
     A \emph{pair} is an object $p$ such that $p \Eq (a, b)$ for some objects $a, b$.
     Let an \emph{ordered pair} stand for a pair.
   \end{definition}
 \end{sfragment}
 
 \begin{sfragment}{Cartesian Products}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for={SETprod,Cartesian product,direct product}]
     Let $A, B$ be classes.
     $\emph{A \SETprod B} = \CClass{(a, b)}{a \Elem A\text{ and }b \Elem B}$.
     Let the \emph{Cartesian product of $A$ and $B$} stand for $A \SETprod B$.

--- a/math/archive/libraries/foundations/source/proper-classes.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/proper-classes.ftl.en.tex
@@ -4,8 +4,9 @@
 \begin{document}
 \begin{smodule}{proper-classes.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
+\symdecl*{proper class}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=proper class]
   A \emph{proper class} is a class that is not a set.
 \end{definition}
 \end{smodule}

--- a/math/archive/libraries/foundations/source/segments-of-natural-numbers.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/segments-of-natural-numbers.ftl.en.tex
@@ -6,7 +6,7 @@
 \importmodule[libraries/arithmetics]{ordering.ftl}
 \symdef{NATsegment}[args=2]{\comp{\{}#1\comp{,\dots,}#2\comp{\}}}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=NATsegment]
   Let $n, m$ be natural numbers.
   $\emph{\NATsegment{n}{m}} = \SClass{k}{\Nat}{n \NATleq k \NATleq m}$.
 \end{definition}

--- a/math/archive/libraries/foundations/source/sub-and-supersets.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/sub-and-supersets.ftl.en.tex
@@ -4,9 +4,13 @@
 \begin{document}
 \begin{smodule}{sub-and-supersets.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
-\symdef{SETpow}{\mathcal{P}}
+\symdef{SETpow}[name=powerclass]{\mathcal{P}}
+\symdecl*{subset}
+\symdecl*{superset}
+\symdecl*{proper subset}
+\symdecl*{proper superset}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={subset,superset,proper subset,proper superset}]
   Let $A$ be a class.
   A \emph{subset of $A$} is a subclass of $A$ that is a set.
   Let a \emph{superset of $A$} stand for a superclass of $A$ that is a set.
@@ -14,7 +18,7 @@
   Let a \emph{proper superset of $A$} stand for a proper superclass of $A$ that is a set.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=powerclass]
   Let $A$ be a class.
   $\emph{\SETpow(A)}$ is $\CClass{x}{x\text{ is a subset of }A}$.
   Let the \emph{powerclass of $A$} stand for $\SETpow(A)$.

--- a/math/archive/libraries/foundations/source/symmetric-difference.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/symmetric-difference.ftl.en.tex
@@ -4,10 +4,10 @@
 \begin{document}
 \begin{smodule}{symmetric-difference.ftl}
 \importmodule[libraries/foundations]{computation-laws-for-classes.ftl}
-\symdef{SETsymdiff}{\,\triangle\,}
+\symdef{SETsymdiff}[name=symmetric difference]{\,\triangle\,}
 
 \begin{sfragment}{Definitions}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=symmetric difference]
     Let $A, B$ be classes.
     $\emph{A \SETsymdiff B} = (A \SETunion B) \SETdiff (A \SETintersect B)$.
     Let the \emph{symmetric difference of $A$ and $B$} stand for $A \SETsymdiff B$.

--- a/math/archive/libraries/foundations/source/systems-of-countable-and-uncountable-sets.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/systems-of-countable-and-uncountable-sets.ftl.en.tex
@@ -5,16 +5,19 @@
 \begin{smodule}{systems-of-countable-and-uncountable-sets.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{countable-and-uncountable-classes.ftl}
+\symdecl*{system of countably infinite sets}
+\symdecl*{system of countable sets}
+\symdecl*{system of uncountable sets}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of countably infinite sets]
   A \emph{system of countably infinite sets} is a system of sets $X$ such that every element of $X$ is countably infinite.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of countable sets]
   A \emph{system of countable sets} is a system of sets $X$ such that every element of $X$ is countable.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of uncountable sets]
   A \emph{system of uncountable sets} is a system of sets $X$ such that every element of $X$ is uncountable.
 \end{definition}
 \end{smodule}

--- a/math/archive/libraries/foundations/source/systems-of-finite-and-infinite-sets.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/systems-of-finite-and-infinite-sets.ftl.en.tex
@@ -5,12 +5,14 @@
 \begin{smodule}{systems-of-finite-and-infinite-sets.ftl}
 \importmodule[libraries/foundations]{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{finite-and-infinite-classes.ftl}
+\symdecl*{system of finite sets}
+\symdecl*{system of infinite sets}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of finite sets]
   A \emph{system of finite sets} is a system of sets $X$ such that every element of $X$ is finite.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of infinite sets]
   A \emph{system of infinite sets} is a system of sets $X$ such that every element of $X$ is infinite.
 \end{definition}
 \end{smodule}

--- a/math/archive/libraries/foundations/source/systems-of-sets.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/systems-of-sets.ftl.en.tex
@@ -4,18 +4,21 @@
 \begin{document}
 \begin{smodule}{systems-of-sets.ftl}
 \importmodule[libraries/foundations]{sub-and-supersets.ftl}
-\symdef{SETunionover}{\bigcup\,}
-\symdef{SETintersectover}{\bigcap\,}
+\symdef{SETunionover}[name=union over]{\bigcup\,}
+\symdef{SETintersectover}[name=intersection over]{\bigcap\,}
+\symdecl*{system of sets}
+\symdecl*{system of nonempty sets}
+\symdecl*{system of subsets}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of sets]
   A \emph{system of sets} is a class $X$ such that every element of $X$ is a set.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of nonempty sets]
   A \emph{system of nonempty sets} is a class $X$ such that every element of $X$ is a nonempty set.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of subsets]
   Let $A$ be a class.
   A \emph{system of subsets of $A$} is a class $X$ such that every element of $X$ is a subset of $A$.
 \end{definition}
@@ -46,7 +49,7 @@
 \end{proposition}
 
 \begin{sfragment}{Unions Over Systems of Sets}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=union over]
     Let $X$ be a system of sets.
     $\emph{\SETunionover X} = \CClass{a}{a \Elem x\text{ for some }x \Elem X}$.
     Let \emph{union over $X$} stand for $\SETunionover X$.
@@ -89,7 +92,7 @@
 \end{sfragment}
 
 \begin{sfragment}{Intersections Over Systems of Sets}
-  \begin{definition}[forthel]
+  \begin{definition}[forthel,for=intersection over]
     Let $X$ be a system of sets.
     $\emph{\SETintersectover X} = \CClass{a}{a \Elem x\text{ for all }x \Elem X}$.
     Let the \emph{intersection over $X$} stand for $\SETintersectover X$.

--- a/math/archive/libraries/foundations/source/universal-class.ftl.en.tex
+++ b/math/archive/libraries/foundations/source/universal-class.ftl.en.tex
@@ -4,9 +4,9 @@
 \begin{document}
 \begin{smodule}{universal-class.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
-\symdef{Set}{\mathbb V}
+\symdef{Set}[name=universal class]{\mathbb V}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=universal class]
   $\emph{\Set}$ is the collection of all sets.
   Let the \emph{universal class} stand for $\Set$.
 \end{definition}

--- a/math/archive/libraries/lists/source/concatenation.ftl.en.tex
+++ b/math/archive/libraries/lists/source/concatenation.ftl.en.tex
@@ -6,17 +6,17 @@
 \importmodule[libraries/lists]{lists.ftl}
 \symdef{LISTconcat}[op=+\mkern-10mu+]{\,\comp+\mkern-10mu\comp+\,}
 
-\begin{signature}[forthel]
+\begin{signature}[forthel,for=LISTconcat]
   Let $L, L'$ be lists.
   $\emph{L \LISTconcat L'}$ is a list.
 \end{signature}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTconcat]
   Let $L$ be a list.
   Then $\LISTlist{} \LISTconcat L \Eq L$.
 \end{axiom}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTconcat]
   Let $a$ be an object and $L, L'$ be lists.
   Then $(a \LISTcons L) \LISTconcat L' \Eq a \LISTcons (L \LISTconcat L')$.
 \end{axiom}

--- a/math/archive/libraries/lists/source/length.ftl.en.tex
+++ b/math/archive/libraries/lists/source/length.ftl.en.tex
@@ -7,16 +7,16 @@
 \importmodule[libraries/arithmetics]{natural-numbers.ftl}
 \symdef{LISTlength}{\textsf{length}}
 
-\begin{signature}[forthel]
+\begin{signature}[forthel,for=LISTlength]
   Let $L$ be a list.
   $\emph{\LISTlength(L)}$ is a natural number.
 \end{signature}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTlength]
   $\LISTlength(\LISTlist{}) \Eq \NATzero$.
 \end{axiom}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTlength]
   Let $a$ be an object and $L$ be a list.
   Then $\LISTlength(a \LISTcons L) \Eq \LISTlength(L) \NATplus \NATone$.
 \end{axiom}

--- a/math/archive/libraries/lists/source/lists.ftl.en.tex
+++ b/math/archive/libraries/lists/source/lists.ftl.en.tex
@@ -4,18 +4,18 @@
 \begin{document}
 \begin{smodule}{lists.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
-\symdef{LISTlist}[args=a,op=[\,]]{\comp[\argsep{#1}{\comp,}\comp]}
+\symdef{LISTlist}[name=list,args=a,op=[\,]]{\comp[\argsep{#1}{\comp,}\comp]}
 \symdef{LISTcons}[op=::]{\,{::}\,}
 
-\begin{signature}[forthel]
+\begin{signature}[forthel,for=LISTlist]
   A \emph{list} is an object.
 \end{signature}
 
-\begin{signature}[forthel]
+\begin{signature}[forthel,for=LISTlist]
   $\emph{\LISTlist{}}$ is a list.
 \end{signature}
 
-\begin{signature}[forthel]
+\begin{signature}[forthel,for=LISTlist]
   Let $a$ be an object and $L$ be a list.
   $\emph{a \LISTcons L}$ is a list.
   Let $\emph{\LISTlist{a}}$ stand for $a \LISTcons \LISTlist{}$.
@@ -23,12 +23,12 @@
   Let $\emph{\LISTlist{a,b,c}}$ stand for $a \LISTcons \LISTlist{b,c}$.
 \end{signature}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTlist]
   Let $L$ be a list.
   Then $L \Eq \LISTlist{}$ or $L \Eq a \LISTcons L'$ for some object $a$ and some list $L'$.
 \end{axiom}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTlist]
   Let $a$ be an object and $L$ be a list.
   Then $L \prec a \LISTcons L$.
 \end{axiom}

--- a/math/archive/libraries/lists/source/reversion.ftl.en.tex
+++ b/math/archive/libraries/lists/source/reversion.ftl.en.tex
@@ -6,17 +6,17 @@
 \importmodule[libraries/lists]{concatenation.ftl}
 \symdef{LISTrev}{\textsf{rev}}
 
-\begin{signature}[forthel]
+\begin{signature}[forthel,for=LISTrev]
   Let $L$ be a list.
   $\emph{\LISTrev(L)}$ is a list.
 \end{signature}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTrev]
   Let $L$ be a list.
   Then $\LISTrev(\LISTlist{}) \Eq \LISTlist{}$.
 \end{axiom}
 
-\begin{axiom}[forthel]
+\begin{axiom}[forthel,for=LISTrev]
   Let $a$ be an object and $L$ be a list.
   Then $\LISTrev(a \LISTcons L) \Eq \LISTrev(L) \LISTconcat \LISTlist{a}$.
 \end{axiom}

--- a/math/archive/libraries/meta/source/notions/application.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/application.ftl.en.tex
@@ -7,7 +7,6 @@
 \importmodule[libraries/meta]{notions?domain.ftl}
 \importmodule[libraries/meta]{notions?elements.ftl}
 
-\symdecl*{map}
 \symdecl*{value}
 
 \begin{fakeforthel}
@@ -18,7 +17,7 @@
 \end{fakeforthel}
 
 \begin{forthel}
-  \begin{convention}
+  \begin{convention}[for=value]
     Let the \emph{value of $f$ at $x$} stand for $f(x)$.
     Let $\emph{f(x,y)}$ stand for $f((x,y))$.
   \end{convention}

--- a/math/archive/libraries/meta/source/notions/classes.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/classes.ftl.en.tex
@@ -8,7 +8,7 @@
 \symdecl*{collection}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for={class,collection}]
     A \emph{class} is a notion.
     Let a \emph{collection} stand for a class.
   \end{signature}

--- a/math/archive/libraries/meta/source/notions/comprehension-class.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/comprehension-class.ftl.en.tex
@@ -7,10 +7,10 @@
 \importmodule[libraries/meta]{notions?classes.ftl}
 \importmodule[libraries/meta]{notions?objects.ftl}
 
-\symdef{CClass}[args=2,name=comprehension class]{\comp{\left\{\right.}#1\,\comp{\left.\middle|\right.}\,#2\comp{\left.\right\}}}
+\symdef{CClass}[args=2]{\comp{\left\{\right.}#1\,\comp{\left.\middle|\right.}\,#2\comp{\left.\right\}}}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for=CClass]
     Let $\tau$ be a term and $\varphi$ be a formula.
     $\emph{\CClass{\tau}{\varphi}}$ is a class.
   \end{signature}

--- a/math/archive/libraries/meta/source/notions/domain.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/domain.ftl.en.tex
@@ -10,16 +10,18 @@
 \symdef{Dom}[name=domain]{\comp{\textrm{dom}}}
 \symdecl*{defined}
 
+\STEXinvisible{\inlineforthel{Let the domain of $f$ stand for $\Dom(f)$.}}
+
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for=Dom]
     Let $f$ be a map.
     $\emph{\Dom(f)}$ is a class.
+    Let the \emph{domain of $f$} stand for $\Dom(f)$.
   \end{signature}
 \end{fakeforthel}
 
 \begin{forthel}
-  \begin{convention}
-    Let the \emph{domain of $f$} stand for $\Dom(f)$.
+  \begin{convention}[for=defined]
     Let $f$ is \emph{defined on $X$} stand for $\Dom(f) = X$.
   \end{convention}
 \end{forthel}

--- a/math/archive/libraries/meta/source/notions/elements.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/elements.ftl.en.tex
@@ -17,17 +17,16 @@
 \symdecl*{in}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for={element,Elem,NotElem}]
     Let $A$ be a class.
     A \emph{element of $A$} is an object.
-
     Let $\emph{a \Elem A}$ stand for $a$ is an element of $A$.
     Let $\emph{a \NotElem A}$ stand for $a$ is not an element of $A$.
   \end{signature}
 \end{fakeforthel}
 
 \begin{forthel}
-  \begin{convention}
+  \begin{convention}[for={member,belong,contain,lie,in}]
     Let a \emph{member of $X$} stand for an element of $X$.
     Let $x$ \emph{belongs to $X$} stand for $x$ is an element of $X$.
     Let $X$ \emph{contains $x$} stand for $x$ is an element of $X$.

--- a/math/archive/libraries/meta/source/notions/enumeration-class.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/enumeration-class.ftl.en.tex
@@ -7,10 +7,10 @@
 \importmodule[libraries/meta]{notions?classes.ftl}
 \importmodule[libraries/meta]{notions?objects.ftl}
 
-\symdef{EClass}[args=a,name=enumeration class]{\comp{\left\{\right.}\argsep{#1}{\comp,}\comp{\left.\right\}}}
+\symdef{EClass}[args=a]{\comp{\left\{\right.}\argsep{#1}{\comp,}\comp{\left.\right\}}}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for=EClass]
     Let $a_1,\dots,a_n$ be objects.
     $\emph{\EClass{a1,\dots,a_n}}$ is a class.
   \end{signature}

--- a/math/archive/libraries/meta/source/notions/functions.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/functions.ftl.en.tex
@@ -10,7 +10,7 @@
 \symdecl*{function}
 
 \begin{fakeforthel}
-  \begin{definition}
+  \begin{definition}[for=function]
     A \emph{function} is a map that is an object.
   \end{definition}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/notions/map-terms.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/map-terms.ftl.en.tex
@@ -10,7 +10,7 @@
 \symdef{Map}[args=2]{\comp\lambda#1\mathrel{\comp\in}#2\comp.\,}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for=Map]
     Let $v$ be a variable, $A$ be a class and $\tau$ be a term.
     $\emph{\Map{v}{A}\tau}$ is a map.
   \end{signature}

--- a/math/archive/libraries/meta/source/notions/maps.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/maps.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdecl*{map}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for=map]
     A \emph{map} is a notion.
   \end{signature}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/notions/objects.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/objects.ftl.en.tex
@@ -8,9 +8,8 @@
 \symdecl*{element}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for={object,element}]
     A \emph{mathematical object} is a notion.
-    
     Let an \emph{object} stand for a mathematical object.
     Let an \emph{element} stand for a mathematical object.
   \end{signature}

--- a/math/archive/libraries/meta/source/notions/pairs.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/pairs.ftl.en.tex
@@ -17,7 +17,7 @@
 \end{fakeforthel}
 
 \begin{forthel}
-  \begin{convention}
+  \begin{convention}[for=ordered pair]
     Let the \emph{ordered pair of $a$ and $b$} stand for $(a,b)$.
     Let an \emph{ordered pair} stand for an object $x$ such that $x \Eq (a,b)$ for some objects $a, b$.
   \end{convention}

--- a/math/archive/libraries/meta/source/notions/separation-class.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/separation-class.ftl.en.tex
@@ -7,10 +7,10 @@
 \importmodule[libraries/meta]{notions?classes.ftl}
 \importmodule[libraries/meta]{notions?objects.ftl}
 
-\symdef{SClass}[args=3,separation class]{\comp{\left\{\right.}#1\comp\in#2\,\comp{\left.\middle|\right.}\,#3\comp{\left.\right\}}}
+\symdef{SClass}[args=3]{\comp{\left\{\right.}#1\comp\in#2\,\comp{\left.\middle|\right.}\,#3\comp{\left.\right\}}}
 
 \begin{fakeforthel}
-  \begin{signature}
+  \begin{signature}[for=SClass]
     Let $\tau$ be a term, $A$ be a class and $\varphi$ be a formula.
     $\emph{\SClass{\tau}{A}{\varphi}}$ is a class.
   \end{signature}

--- a/math/archive/libraries/meta/source/notions/sets.ftl.en.tex
+++ b/math/archive/libraries/meta/source/notions/sets.ftl.en.tex
@@ -10,7 +10,7 @@
 \symdecl*{set}
 
 \begin{fakeforthel}
-  \begin{definition}
+  \begin{definition}[for=set]
     A \emph{set} is a class that is an object.
   \end{definition}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/conjunction.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/conjunction.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdef{And}{\mathop{\comp\wedge}}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=And]
     Let $\emph{\varphi \And \psi}$ stand for $\varphi$ and $\psi$.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/disjunction.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/disjunction.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdef{Or}{\mathop{\comp\vee}}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=Or]
     Let $\emph{\varphi \Or \psi}$ stand for $\varphi$ or $\psi$.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/equivalence.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/equivalence.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdef{Iff}{\mathop{\comp\Longleftrightarrow}}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=Iff]
     Let $\emph{\varphi \Iff \psi}$ stand for $\varphi$ iff $\psi$.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/existential-quantification.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/existential-quantification.ftl.en.tex
@@ -9,7 +9,7 @@
 \symdef{Exists}{\mathop\exists}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=Exists]
     Let $\emph{\Exists} x \mathrel{R} y : \varphi$ stand for there exists an $x \mathrel{R} y$ such that $\varphi$.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/falsity.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/falsity.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdef{False}{\comp\bot}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=False]
     Let $\emph{\False}$ stand for falsity.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/implication.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/implication.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdef{Implies}{\mathop{\comp\Longrightarrow}}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=Implies]
     Let $\emph{\varphi \Implies \psi}$ stand for $\varphi$ implies $\psi$.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/negation.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/negation.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdef{Not}{\mathop{\comp\neg}}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=Not]
     Let $\emph{\Not \varphi}$ stand for not $\varphi$.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/truth.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/truth.ftl.en.tex
@@ -7,7 +7,7 @@
 \symdef{True}{\comp\top}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=True]
     Let $\emph{\True}$ stand for truth.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/propositions/universal-quantification.ftl.en.tex
+++ b/math/archive/libraries/meta/source/propositions/universal-quantification.ftl.en.tex
@@ -9,7 +9,7 @@
 \symdef{Forall}{\mathop\forall}
 
 \begin{fakeforthel}
-  \begin{convention}
+  \begin{convention}[for=Forall]
     Let $\emph{\Forall} x \mathrel{R} y : \varphi$ stand for for all $x \mathrel{R} y$ we have $\varphi$.
   \end{convention}
 \end{fakeforthel}

--- a/math/archive/libraries/meta/source/relations/equality.ftl.en.tex
+++ b/math/archive/libraries/meta/source/relations/equality.ftl.en.tex
@@ -9,15 +9,27 @@
 \symdecl*{agree}
 \symdecl*{distinct}
 
+\begin{fakeforthel}
+  \begin{convention}[for=Eq]
+    Let $\emph{x \Eq y}$ stand for $x$ is equal to $y$.
+  \end{convention}
+\end{fakeforthel}
+
+\begin{fakeforthel}
+  \begin{convention}[for=NotEq]
+    Let $\emph{x \NotEq y}$ stand for $x$ is not equal to $y$.
+  \end{convention}
+\end{fakeforthel}
+
 \begin{forthel}
-  \begin{convention}
-    Let $x$ and $y$ \emph{agree} stand for $x$ is equal to $y$.
-    Let $x$ \emph{agrees with $y$} stand for $x$ is equal to $y$.
+  \begin{convention}[for=agree]
+    Let $x$ and $y$ \emph{agree} stand for $x \Eq y$.
+    Let $x$ \emph{agrees with $y$} stand for $x \Eq y$.
   \end{convention}
 \end{forthel}
 
 \begin{forthel}
-  \begin{convention}
+  \begin{convention}[for=distinct]
     Let $x$ and $y$ are \emph{distinct} stand for $x \NotEq y$.
   \end{convention}
 \end{forthel}

--- a/math/archive/libraries/meta/source/relations/induction-order.ftl.en.tex
+++ b/math/archive/libraries/meta/source/relations/induction-order.ftl.en.tex
@@ -4,13 +4,13 @@
 \begin{document}
 \begin{smodule}{induction-order.ftl}
 
-\symdef{ILess}[name=inductively less]{\mathrel{\comp\prec}}
+\symdef{ILess}{\mathrel{\comp\prec}}
 
-\begin{forthel}
-  \begin{convention}
-    Let $x$ is \emph{inductively less than $y$} stand for $x \ILess y$.
+\begin{fakeforthel}
+  \begin{convention}[for=ILess]
+    Let $\emph{x \ILess y}$ stand for $x$ is inductively less than $y$.
   \end{convention}
-\end{forthel}
+\end{fakeforthel}
 
 \end{smodule}
 \end{document}

--- a/math/archive/libraries/set-theory/source/axioms/infinity.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/axioms/infinity.ftl.en.tex
@@ -5,10 +5,11 @@
 \begin{smodule}{infinity.ftl}
 \importmodule[libraries/foundations]{maps.ftl}
 \importmodule[libraries/foundations]{sub-and-supersets.ftl}
+\symdecl*{inductive}
 
 \symdecl*{Axiom of Infinity}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=inductive]
   Let $A$ be a class and $a$ be an object and $f$ be a map such that $A \SETinclude \Dom(f)$.
   $A$ is \emph{inductive regarding $a$ and $f$} iff $a \Elem A$ and for all $x \Elem A$ we have $f(x) \Elem A$.
 \end{definition}

--- a/math/archive/libraries/set-theory/source/axioms/pairing.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/axioms/pairing.ftl.en.tex
@@ -4,6 +4,7 @@
 \begin{document}
 \begin{smodule}{pairing.ftl}
 \importmodule[libraries/foundations]{classes.ftl}
+\symdecl*{singleton set}
 
 \symdecl*{Pairing Axiom}
 
@@ -17,7 +18,7 @@
   Then $\SETsingleton{a}$ is a set.
 \end{proposition}
 
-\begin{convention}[forthel]
+\begin{convention}[forthel,for=singleton set]
   Let the singleton set of $a$ stand for the singleton class of $a$.
   Let a singleton set stand for a singleton class.
 \end{convention}

--- a/math/archive/libraries/set-theory/source/cardinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/cardinals.ftl.en.tex
@@ -6,15 +6,17 @@
 \importmodule[libraries/set-theory]{axioms?choice.ftl}
 \importmodule[libraries/set-theory]{ordering.ftl}
 \importmodule[libraries/foundations]{equinumerosity.ftl}
-\symdef{SETcard}[args=1]{\comp|#1\comp|}
+\symdef{SETcard}[name=cardinality,args=1]{\comp|#1\comp|}
+\symdecl*{cardinal number}
+\symdecl*{cardinal}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=cardinality]
   Let $x$ be a set.
   $\emph{\SETcard{x}}$ is the ordinal $\kappa$ such that $\kappa$ is equinumerous to $x$ and every ordinal that is equinumerous to $x$ is greater than or equal to $\kappa$.
   Let the \emph{cardinality of $x$} stand for $\SETcard{x}$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={cardinal number,cardinal}]
   A \emph{cardinal number} is an ordinal $\kappa$ such that $\kappa \Eq \SETcard{x}$ for some
   set $x$.
   Let a \emph{cardinal} stand for a cardinal number.

--- a/math/archive/libraries/set-theory/source/cofinality.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/cofinality.ftl.en.tex
@@ -5,8 +5,10 @@
 \begin{smodule}{cofinality.ftl}
 \importmodule[libraries/set-theory]{cardinals.ftl}
 \importmodule[libraries/set-theory]{finite-and-infinite-sets.ftl}
+\symdecl*{cofinal}
+\symdecl*{cofinal subset}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={cofinal,cofinal subset}]
   Let $\kappa$ be a cardinal and $Y \SETinclude \kappa$.
   $Y$ is \emph{cofinal in $\kappa$} iff for every $x \Elem \kappa$ there exists a $y \Elem Y$ such that $x \ORDless y$.
   Let a \emph{cofinal subset of $\kappa$} stand for a subset of $\kappa$ that is cofinal in $\kappa$.

--- a/math/archive/libraries/set-theory/source/countable-and-uncountable-sets.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/countable-and-uncountable-sets.ftl.en.tex
@@ -5,18 +5,21 @@
 \begin{smodule}{countable-and-uncountable-sets.ftl}
 \importmodule[libraries/set-theory]{omega-is-limit-ordinal.ftl}
 \importmodule[libraries/set-theory]{cardinals.ftl}
+\symdecl*{countable}
+\symdecl*{uncountable}
+\symdecl*{countably infinite}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=countable]
   Let $x$ be a set.
   $x$ is \emph{countable} iff $\SETcard{x} \ORDleq \ORDomega$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=uncountable]
   Let $x$ be a set.
   $x$ is \emph{uncountable} iff $x$ is not countable.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=countably infinite]
   Let $x$ be a set.
   $x$ is \emph{countably infinite} iff $\SETcard{x} \Eq \ORDomega$.
 \end{definition}

--- a/math/archive/libraries/set-theory/source/finite-and-infinite-sets.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/finite-and-infinite-sets.ftl.en.tex
@@ -4,13 +4,15 @@
 \begin{document}
 \begin{smodule}{finite-and-infinite-sets.ftl}
 \importmodule[libraries/set-theory]{omega-is-cardinal.ftl}
+\symdecl*{finite}
+\symdecl*{infinite}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=finite]
   Let $x$ be a set.
   $x$ is \emph{finite} iff $\SETcard{x} \ORDless \ORDomega$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=infinite]
   Let $x$ be a set.
   $x$ is \emph{infinite} iff $x$ is not finite.
 \end{definition}

--- a/math/archive/libraries/set-theory/source/infinite-cardinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/infinite-cardinals.ftl.en.tex
@@ -8,7 +8,7 @@
 \importmodule[articles]{cantor.ftl}
 \symdef{Card}{\mathbb C}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=Card]
   $\emph{\Card}$ is the collection of all infinite cardinals.
 \end{definition}
 

--- a/math/archive/libraries/set-theory/source/limit-ordinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/limit-ordinals.ftl.en.tex
@@ -6,8 +6,9 @@
 \importmodule[libraries/set-theory]{zero.ftl}
 \importmodule[libraries/set-theory]{successor-ordinals.ftl}
 \symdef{ORDlim}{\mathop{\textsf{lim}}}
+\symdecl*{limit ordinal}
 
-\begin{convention}[forthel]
+\begin{convention}[forthel,for=ORDlim]
   Let $\ORDlim x$ stand for $\SETunionover x$.
 \end{convention}
 
@@ -37,7 +38,7 @@
   \end{proof}
 \end{proof}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=limit ordinal]
   A \emph{limit ordinal} is an ordinal $\lambda$ such that neither $\lambda$ is a successor ordinal nor $\lambda \Eq \ORDzero$.
 \end{definition}
 \end{smodule}

--- a/math/archive/libraries/set-theory/source/omega.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/omega.ftl.en.tex
@@ -6,8 +6,9 @@
 \importmodule[libraries/set-theory]{zero.ftl}
 \importmodule[libraries/set-theory]{successor-ordinals.ftl}
 \symdef{ORDomega}{\omega}
+\symdecl*{natural number}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={ORDomega,natural number}]
   \[ \emph{\ORDomega} = \SClass{n}{\Ord}{\classtext{$n \Elem X$ for every $X \SETinclude \Ord$ such that $\ORDzero \Elem X$ and for all $x \Elem X$ we have $\ORDsucc(x) \Elem X$}}. \]
   Let a \emph{natural number} stand for an element of $\ORDomega$.
 \end{definition}

--- a/math/archive/libraries/set-theory/source/one.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/one.ftl.en.tex
@@ -7,7 +7,7 @@
 \importmodule[libraries/set-theory]{successor-ordinals.ftl}
 \symdef{ORDone}{1}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=ORDone]
   $\emph{\ORDone} = \ORDsucc(\ORDzero)$.
 \end{definition}
 

--- a/math/archive/libraries/set-theory/source/ordering.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/ordering.ftl.en.tex
@@ -4,16 +4,16 @@
 \begin{document}
 \begin{smodule}{ordering.ftl}
 \importmodule[libraries/set-theory]{limit-ordinals.ftl}
-\symdef{ORDless}{\;<\;}
+\symdef{ORDless}[name=less]{\;<\;}
 \symdef{ORDnless}{\;\not<\;}
 \symdef{ORDleq}{\;\leq\;}
 \symdef{ORDnleq}{\;\not\leq\;}
-\symdef{ORDgtr}{\;>\;}
+\symdef{ORDgtr}[name=greater]{\;>\;}
 \symdef{ORDngtr}{\;\not>\;}
 \symdef{ORDgeq}{\;\geq\;}
 \symdef{ORDngeq}{\;\not\geq\;}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={less,ORDnless,greater,ORDngtr}]
   Let $\alpha, \beta$ be ordinals.
   $\emph{\alpha \ORDless \beta}$ iff $\alpha \Elem \beta$.
   Let $\alpha$ is \emph{less than $\beta$} stand for $\alpha \ORDless \beta$.
@@ -23,7 +23,7 @@
   Let $\emph{\alpha \ORDngtr \beta}$ stand for not $\alpha \ORDgtr \beta$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={ORDleq,ORDnleq,ORDgeq,ORDngeq}]
   Let $\alpha, \beta$ be ordinals.
   $\emph{\alpha \ORDleq \beta}$ iff $\alpha \ORDless \beta$ or $\alpha \Eq \beta$.
   Let $\alpha$ is \emph{less than or equal to $\beta$} stand for $\alpha \ORDleq \beta$.

--- a/math/archive/libraries/set-theory/source/ordinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/ordinals.ftl.en.tex
@@ -5,13 +5,15 @@
 \begin{smodule}{ordinals.ftl}
 \importmodule[libraries/set-theory]{transitive-classes.ftl}
 \symdef{Ord}{\mathbb O}
+\symdecl*{ordinal number}
+\symdecl*{ordinal}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for={ordinal number,ordinal}]
   An \emph{ordinal number} is a transitive set $\alpha$ such that every element of $\alpha$ is a transitive set.
   Let an \emph{ordinal} stand for an ordinal number.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=Ord]
   $\emph{\Ord}$ is the class of all ordinals.
 \end{definition}
 

--- a/math/archive/libraries/set-theory/source/recursive-maps.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/recursive-maps.ftl.en.tex
@@ -5,8 +5,9 @@
 \begin{smodule}{recursive-maps.ftl}
 \importmodule[libraries/set-theory]{ordering.ftl}
 \symdef{ORDfunspace}[args=1]{#1^{\comp{<\infty}}}
+\symdecl*{recursive}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=ORDfunspace]
   Let $A$ be a class.
   \[ \emph{\ORDfunspace{A}} = \CClass{f}{f\text{ is a map from }\alpha\text{ to }A\text{ for some ordinal }\alpha}. \]
 \end{definition}
@@ -18,7 +19,7 @@
 
 \inlineforthel{[prover vampire]}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=recursive]
   Let $H$ be a map and $G \FUNfromto{\ORDfunspace{A}}{A}$ for some class $A$ such that $H$ is a map to $A$.
   $H$ is \emph{recursive regarding $G$} iff $\Dom(H)$ is a transitive subclass of $\Ord$ and for all $\alpha \Elem \Dom(H)$ we have \[ H(\alpha) \Eq G(H \FUNrest \alpha). \]
 \end{definition}

--- a/math/archive/libraries/set-theory/source/regular-cardinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/regular-cardinals.ftl.en.tex
@@ -4,8 +4,9 @@
 \begin{document}
 \begin{smodule}{regular-cardinals.ftl}
 \importmodule[libraries/set-theory]{cofinality.ftl}
+\symdecl*{regular}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=regular]
   Let $\kappa$ be a cardinal.
   $\kappa$ is \emph{regular} iff $\SETcard{x} \Eq \kappa$ for every cofinal subset $x$ of $\kappa$.
 \end{definition}

--- a/math/archive/libraries/set-theory/source/successor-cardinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/successor-cardinals.ftl.en.tex
@@ -6,6 +6,7 @@
 \importmodule[libraries/set-theory]{cardinals.ftl}
 \importmodule[articles]{cantor.ftl}
 \symdef{CARDsucc}[args=1]{#1^{\comp+}}
+\symdecl*{successor cardinal}
 
 \begin{lemma}[forthel]
   For every ordinal $\alpha$ there exists a cardinal greater than $\alpha$.
@@ -28,12 +29,12 @@
   End.
 \end{proof}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=CARDsucc]
   Let $\kappa$ be a cardinal.
   $\emph{\CARDsucc{\kappa}}$ is the cardinal such that $\kappa \ORDless \CARDsucc{\kappa}$ and there is no cardinal $\nu$ such that $\kappa \ORDless \nu \ORDless \CARDsucc{\kappa}$.
 \end{definition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=successor cardinal]
   A \emph{successor cardinal} is a cardinal number $\kappa$ such that $\kappa \Eq \CARDsucc{\nu}$ for some cardinal number $\nu$.
 \end{definition}
 

--- a/math/archive/libraries/set-theory/source/successor-ordinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/successor-ordinals.ftl.en.tex
@@ -6,8 +6,9 @@
 \importmodule[libraries/set-theory]{ordinals.ftl}
 \symdef{ORDsucc}{\textrm{succ}}
 \symdef{ORDpred}{\textrm{pred}}
+\symdecl*{successor ordinal}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=ORDsucc]
   Let $\alpha$ be an ordinal.
   $\emph{\ORDsucc(\alpha)} = \alpha \SETunion \SETsingleton{\alpha}$.
 \end{definition}
@@ -34,7 +35,7 @@
   \end{proof}
 \end{proof}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=successor ordinal]
   A \emph{successor ordinal} is an ordinal $\alpha$ such that $\alpha \Eq \ORDsucc(\beta)$ for some ordinal $\beta$.
 \end{definition}
 
@@ -84,7 +85,7 @@
   \end{proof}
 \end{proof}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=ORDpred]
   Let $\alpha$ be a successor ordinal.
   $\emph{\ORDpred(\alpha)}$ is the ordinal $\beta$ such that $\alpha \Eq \ORDsucc(\beta)$.
 \end{definition}

--- a/math/archive/libraries/set-theory/source/transitive-classes.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/transitive-classes.ftl.en.tex
@@ -4,8 +4,10 @@
 \begin{document}
 \begin{smodule}{transitive-classes.ftl}
 \importmodule[libraries/set-theory]{zfc.ftl}
+\symdecl*{transitive}
+\symdecl*{system of transitive sets}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=transitive]
   Let $A$ be a class.
   $A$ is \emph{transitive} iff every element of $A$ is a subset of $A$.
 \end{definition}
@@ -15,7 +17,7 @@
   Then $X$ is transitive iff for every $x \Elem X$ and every $y \Elem x$ we have $y \Elem X$.
 \end{proposition}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=system of transitive sets]
   A \emph{system of transitive sets} is a system of sets $X$ such that every member of $X$ is a transitive set.
 \end{definition}
 

--- a/math/archive/libraries/set-theory/source/two.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/two.ftl.en.tex
@@ -6,7 +6,7 @@
 \importmodule[libraries/set-theory]{one.ftl}
 \symdef{ORDtwo}{2}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=ORDtwo]
   $\emph{\ORDtwo} = \ORDsucc(\ORDone)$.
 \end{definition}
 

--- a/math/archive/libraries/set-theory/source/weak-limit-cardinals.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/weak-limit-cardinals.ftl.en.tex
@@ -4,8 +4,9 @@
 \begin{document}
 \begin{smodule}{weak-limit-cardinals.ftl}
 \importmodule[libraries/set-theory]{successor-cardinals.ftl}
+\symdecl*{weak limit cardinal}
 
-\begin{definition}[forthel]
+\begin{definition}[forthel,for=weak limit cardinal]
   A \emph{weak limit cardinal} is a cardinal number $\lambda$ such that $\lambda$ is not a successor cardinal and $\lambda \neq \ORDzero$.
 \end{definition}
 \end{smodule}

--- a/math/archive/libraries/set-theory/source/zero.ftl.en.tex
+++ b/math/archive/libraries/set-theory/source/zero.ftl.en.tex
@@ -6,7 +6,7 @@
 \importmodule[libraries/set-theory]{ordinals.ftl}
 \symdef{ORDzero}{0}
 
-\begin{convention}[forthel]
+\begin{convention}[forthel,for=ORDzero]
   Let $\emph{\ORDzero}$ stand for $\SETempty$.
   Let $\alpha$ is \emph{nonzero} stand for $\alpha \neq \ORDzero$.
 \end{convention}

--- a/src/SAD/ForTheL/Base.hs
+++ b/src/SAD/ForTheL/Base.hs
@@ -111,7 +111,11 @@ initFState = FState
   0 0 0
   []
   where
-    primAdjs = [equalAdj, nonequalAdj]
+    primAdjs = [
+        equalAdj,
+        nonequalAdj,
+        inductivelyLessAdj
+      ]
     primNotions = [
         mapNotion,
         functionNotion,
@@ -130,6 +134,8 @@ initFState = FState
     equalAdj = ([Word ["equal"], Word ["to"], Vr], mkTrm EqualityId TermEquality)
     -- "nonequal to x"
     nonequalAdj = ([Word ["nonequal"], Word ["to"], Vr], Not . mkTrm EqualityId TermEquality)
+    -- "inductively less than x"
+    inductivelyLessAdj = ([Word ["inductively"], Word ["less"], Word ["than"], Vr], mkTrm LessId TermLess)
     -- "a map f"
     mapNotion = ([Word ["map", "maps"], Nm], mkMap . head)
     -- "a function f"


### PR DESCRIPTION
* Add `for` parameters to `definition`/`signature`/`convention` environments to make symbolic notions hoverable and to make non-symbolic notions searchable in FLAMS
* Comment out Sextus' Empiricus Syllogism in `socrates.ftl.en.tex` which fails to be parsed due to two ambiguity errors