### PR TITLE
fix file selection in `isabelle naproche_test`

### DIFF
--- a/Isabelle/src/scala/naproche_test.scala
+++ b/Isabelle/src/scala/naproche_test.scala
@@ -25,8 +25,9 @@ object Naproche_Test {
 
     def relative(file: JFile): Path = File.relative_path(Naproche.math, File.path(file)).get
     def relative_name(file: JFile): String = relative(file).implode
+    def contains_flams_dir(path: String): Boolean = path.containsSlice("/.flams/")
     val tests =
-      File.find_files(Naproche.math.file, file => file_format.detect(file.getName))
+      File.find_files(Naproche.math.file, file => file_format.detect(file.getName) && !contains_flams_dir(relative(file).implode))
         .sortBy(relative_name)
 
     val bad = Synchronized(List.empty[Path])

--- a/src/SAD/Main.hs
+++ b/src/SAD/Main.hs
@@ -108,6 +108,7 @@ mainTerminal initInstrs nonInstrArgs = do
               let dialect = case reverse fileNameExtensions of
                     "ftl" : _ -> Ftl
                     "tex" : "ftl" : _ -> Tex
+                    "tex" : "en" : "ftl" : _ -> Tex
                     _ -> error $ "Invalid file name extension: " ++ fileNameExteisionStr
               inputText <- make_bytes <$> File.read filePath
               return (dialect, inputText, Just filePath)


### PR DESCRIPTION
* Files in `.flams` directories are ignored in `isabelle naproche_test`
* Fixed that files with extension `.ftl.en.tex` were rejected in the command line interface (and hence in `isabelle naproche_test`)